### PR TITLE
Find the right files for Tivc123

### DIFF
--- a/boards/lptm4c123gh6pm.json
+++ b/boards/lptm4c123gh6pm.json
@@ -1,0 +1,40 @@
+{
+  "build": {
+    "arduino":{
+      "ldscript": "lm4fcpp_blizzard.ld"
+    },
+    "core": "tivac",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DENERGIA_ARCH_TIVAC -DENERGIA_EK_TM4C123GXL",
+    "f_cpu": "80000000L",
+    "mcu": "lptm4c123gh6pm",
+    "variant": "EK-TM4C123GXL"
+  },
+  "debug": {
+    "svd_path": "TM4C123GH6PM.svd",
+    "tools": {
+      "ti-icdi": {
+        "onboard": true,
+        "server": {
+          "arguments": [
+            "-s", "$PACKAGE_DIR/scripts",
+            "-f", "board/ek-tm4c123gxl.cfg"
+          ],
+          "executable": "bin/openocd",
+          "package": "tool-openocd"
+        }
+      }
+    }
+  },
+  "frameworks": [
+    "arduino",
+    "libopencm3"
+  ],
+  "name": "TI LaunchPad (Tiva C) w/ tm4c123 (80MHz)",
+  "upload": {
+    "maximum_ram_size": 32768,
+    "maximum_size": 262144
+  },
+  "url": "http://www.ti.com/ww/en/launchpad/launchpads-connected-ek-tm4c123gxl.html",
+  "vendor": "TI"
+}

--- a/builder/frameworks/energia.py
+++ b/builder/frameworks/energia.py
@@ -85,6 +85,8 @@ env.Append(
     ]
 )
 
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(LDSCRIPT_PATH=env.BoardConfig().get("build.arduino.ldscript", ""))
 
 #
 # Target: Build Core Library

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -26,3 +26,9 @@ board = lptm4c1294ncpdt
 platform = titiva
 framework = energia
 board = lptm4c1294ncpdt
+
+[env:development]
+platform = https://github.com/ProgmaticProgrammer/platform-titiva.git#feature/refactored-ldscripts
+# use driverlib form Arduino framework
+framework = arduino
+board = lptm4c123gh6pm

--- a/examples/arduino-internal-libs/platformio.ini
+++ b/examples/arduino-internal-libs/platformio.ini
@@ -21,3 +21,9 @@ board = lptm4c1230c3pm
 platform = titiva
 framework = arduino
 board = lptm4c1294ncpdt
+
+[env:development]
+platform = https://github.com/ProgmaticProgrammer/platform-titiva.git#feature/refactored-ldscripts
+# use driverlib form Arduino framework
+framework = arduino
+board = lptm4c123gh6pm

--- a/examples/native-blink/platformio.ini
+++ b/examples/native-blink/platformio.ini
@@ -19,6 +19,12 @@ platform = titiva
 framework = arduino
 board = lptm4c1230c3pm
 
+[env:lptm4c1230c3pm]
+platform = titiva
+# use driverlib form Arduino framework
+framework = arduino
+board = lptm4c123gh6pm
+
 [env:lptm4c1294ncpdt]
 platform = titiva
 # use driverlib form Arduino framework

--- a/examples/native-blink/platformio.ini
+++ b/examples/native-blink/platformio.ini
@@ -19,7 +19,7 @@ platform = titiva
 framework = arduino
 board = lptm4c1230c3pm
 
-[env:lptm4c1230c3pm]
+[env:lptm4c123gh6pm]
 platform = titiva
 # use driverlib form Arduino framework
 framework = arduino

--- a/examples/native-blink/platformio.ini
+++ b/examples/native-blink/platformio.ini
@@ -19,8 +19,8 @@ platform = titiva
 framework = arduino
 board = lptm4c1230c3pm
 
-[env:lptm4c123gh6pm]
-platform = titiva
+[env:development]
+platform = https://github.com/ProgmaticProgrammer/platform-titiva.git#feature/refactored-ldscripts
 # use driverlib form Arduino framework
 framework = arduino
 board = lptm4c123gh6pm

--- a/misc/svd/TM4C123GH6PM.svd
+++ b/misc/svd/TM4C123GH6PM.svd
@@ -1,0 +1,25219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<device xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" schemaVersion="1.1" xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
+  <vendor>Texas Instruments</vendor>
+  <vendorID>TI</vendorID>
+  <name>TM4C123GH6PM</name>
+  <series>TM4C</series>
+  <version>11073</version>
+  <description>ARM Cortex-M4 Tiva TM4C Device</description>
+  <licenseText>
+\n
+    Software License Agreement\n
+\n
+    Texas Instruments (TI) is supplying this software for use solely and\n
+    exclusively on TI's microcontroller products. The software is owned by\n
+    TI and/or its suppliers, and is protected under applicable copyright\n
+    laws. You may not combine this software with "viral" open-source\n
+    software in order to form a larger program.\n
+\n
+    THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.\n
+    NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT\n
+    NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n
+    A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY\n
+    CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL\n
+    DAMAGES, FOR ANY REASON WHATSOEVER.\n
+\n
+  </licenseText>
+  <cpu>
+    <name>CM4</name>
+    <revision>r1p2</revision>
+    <endian>little</endian>
+    <mpuPresent>true</mpuPresent>
+    <fpuPresent>true</fpuPresent>
+    <nvicPrioBits>3</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+  </cpu>
+  <headerSystemFilename>system_TM4C123</headerSystemFilename>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0</resetValue>
+  <resetMask>0</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>WATCHDOG0</name>
+      <description>Register map for WATCHDOG0 peripheral</description>
+      <groupName>WATCHDOG</groupName>
+      <prependToName>WATCHDOG0</prependToName>
+      <baseAddress>0x40000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>WATCHDOG0</name><value>18</value></interrupt>
+      <registers>
+        <register>
+          <name>LOAD</name>
+          <description>Watchdog Load</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_LOAD</name>
+              <description>Watchdog Load Value</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VALUE</name>
+          <description>Watchdog Value</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_VALUE</name>
+              <description>Watchdog Value</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTL</name>
+          <description>Watchdog Control</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_CTL_INTEN</name>
+              <description>Watchdog Interrupt Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>WDT_CTL_RESEN</name>
+              <description>Watchdog Reset Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>WDT_CTL_INTTYPE</name>
+              <description>Watchdog Interrupt Type</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>WDT_CTL_WRC</name>
+              <description>Write Complete</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <description>Watchdog Interrupt Clear</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>WDT_ICR</name>
+              <description>Watchdog Interrupt Clear</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>Watchdog Raw Interrupt Status</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_RIS_WDTRIS</name>
+              <description>Watchdog Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>Watchdog Masked Interrupt Status</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_MIS_WDTMIS</name>
+              <description>Watchdog Masked Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TEST</name>
+          <description>Watchdog Test</description>
+          <addressOffset>0x00000418</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_TEST_STALL</name>
+              <description>Watchdog Stall Enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LOCK</name>
+          <description>Watchdog Lock</description>
+          <addressOffset>0x00000C00</addressOffset>
+          <fields>
+            <field>
+              <name>WDT_LOCK</name>
+              <description>Watchdog Lock</description>
+              <bitRange>[31:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>WDT_LOCK_UNLOCKED</name>
+                  <description>Unlocked</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WDT_LOCK_LOCKED</name>
+                  <description>Locked</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WDT_LOCK_UNLOCK</name>
+                  <description>Unlocks the watchdog timer</description>
+                  <value>0x1acce551</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="WATCHDOG0">
+      <name>WATCHDOG1</name>
+      <prependToName>WATCHDOG1</prependToName>
+      <baseAddress>0x40001000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>GPIOA</name>
+      <description>Register map for GPIOA peripheral</description>
+      <groupName>GPIO</groupName>
+      <prependToName>GPIOA</prependToName>
+      <baseAddress>0x40004000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>GPIOA</name><value>0</value></interrupt>
+      <registers>
+        <register>
+          <name>DATA</name>
+          <description>GPIO Data</description>
+          <addressOffset>0x000003FC</addressOffset>
+        </register>
+        <register>
+          <name>DIR</name>
+          <description>GPIO Direction</description>
+          <addressOffset>0x00000400</addressOffset>
+        </register>
+        <register>
+          <name>IS</name>
+          <description>GPIO Interrupt Sense</description>
+          <addressOffset>0x00000404</addressOffset>
+        </register>
+        <register>
+          <name>IBE</name>
+          <description>GPIO Interrupt Both Edges</description>
+          <addressOffset>0x00000408</addressOffset>
+        </register>
+        <register>
+          <name>IEV</name>
+          <description>GPIO Interrupt Event</description>
+          <addressOffset>0x0000040C</addressOffset>
+        </register>
+        <register>
+          <name>IM</name>
+          <description>GPIO Interrupt Mask</description>
+          <addressOffset>0x00000410</addressOffset>
+          <fields>
+            <field>
+              <name>GPIO_IM_GPIO</name>
+              <description>GPIO Interrupt Mask Enable</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>GPIO Raw Interrupt Status</description>
+          <addressOffset>0x00000414</addressOffset>
+          <fields>
+            <field>
+              <name>GPIO_RIS_GPIO</name>
+              <description>GPIO Interrupt Raw Status</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>GPIO Masked Interrupt Status</description>
+          <addressOffset>0x00000418</addressOffset>
+          <fields>
+            <field>
+              <name>GPIO_MIS_GPIO</name>
+              <description>GPIO Masked Interrupt Status</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <description>GPIO Interrupt Clear</description>
+          <addressOffset>0x0000041C</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>GPIO_ICR_GPIO</name>
+              <description>GPIO Interrupt Clear</description>
+              <bitRange>[7:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AFSEL</name>
+          <description>GPIO Alternate Function Select</description>
+          <addressOffset>0x00000420</addressOffset>
+        </register>
+        <register>
+          <name>DR2R</name>
+          <description>GPIO 2-mA Drive Select</description>
+          <addressOffset>0x00000500</addressOffset>
+        </register>
+        <register>
+          <name>DR4R</name>
+          <description>GPIO 4-mA Drive Select</description>
+          <addressOffset>0x00000504</addressOffset>
+        </register>
+        <register>
+          <name>DR8R</name>
+          <description>GPIO 8-mA Drive Select</description>
+          <addressOffset>0x00000508</addressOffset>
+        </register>
+        <register>
+          <name>ODR</name>
+          <description>GPIO Open Drain Select</description>
+          <addressOffset>0x0000050C</addressOffset>
+        </register>
+        <register>
+          <name>PUR</name>
+          <description>GPIO Pull-Up Select</description>
+          <addressOffset>0x00000510</addressOffset>
+        </register>
+        <register>
+          <name>PDR</name>
+          <description>GPIO Pull-Down Select</description>
+          <addressOffset>0x00000514</addressOffset>
+        </register>
+        <register>
+          <name>SLR</name>
+          <description>GPIO Slew Rate Control Select</description>
+          <addressOffset>0x00000518</addressOffset>
+        </register>
+        <register>
+          <name>DEN</name>
+          <description>GPIO Digital Enable</description>
+          <addressOffset>0x0000051C</addressOffset>
+        </register>
+        <register>
+          <name>LOCK</name>
+          <description>GPIO Lock</description>
+          <addressOffset>0x00000520</addressOffset>
+          <fields>
+            <field>
+              <name>GPIO_LOCK</name>
+              <description>GPIO Lock</description>
+              <bitRange>[31:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>GPIO_LOCK_UNLOCKED</name>
+                  <description>The GPIOCR register is unlocked and may be modified</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GPIO_LOCK_LOCKED</name>
+                  <description>The GPIOCR register is locked and may not be modified</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GPIO_LOCK_KEY</name>
+                  <description>Unlocks the GPIO_CR register</description>
+                  <value>0x4c4f434b</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR</name>
+          <description>GPIO Commit</description>
+          <addressOffset>0x00000524</addressOffset>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>AMSEL</name>
+          <description>GPIO Analog Mode Select</description>
+          <addressOffset>0x00000528</addressOffset>
+        </register>
+        <register>
+          <name>PCTL</name>
+          <description>GPIO Port Control</description>
+          <addressOffset>0x0000052C</addressOffset>
+        </register>
+        <register>
+          <name>ADCCTL</name>
+          <description>GPIO ADC Control</description>
+          <addressOffset>0x00000530</addressOffset>
+        </register>
+        <register>
+          <name>DMACTL</name>
+          <description>GPIO DMA Control</description>
+          <addressOffset>0x00000534</addressOffset>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB</name>
+      <prependToName>GPIOB</prependToName>
+      <baseAddress>0x40005000</baseAddress>
+      <interrupt><name>GPIOB</name><value>1</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOC</name>
+      <prependToName>GPIOC</prependToName>
+      <baseAddress>0x40006000</baseAddress>
+      <interrupt><name>GPIOC</name><value>2</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOD</name>
+      <prependToName>GPIOD</prependToName>
+      <baseAddress>0x40007000</baseAddress>
+      <interrupt><name>GPIOD</name><value>3</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>SSI0</name>
+      <description>Register map for SSI0 peripheral</description>
+      <groupName>SSI</groupName>
+      <prependToName>SSI0</prependToName>
+      <baseAddress>0x40008000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>SSI0</name><value>7</value></interrupt>
+      <registers>
+        <register>
+          <name>CR0</name>
+          <description>SSI Control 0</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_CR0_DSS</name>
+              <description>SSI Data Size Select</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_4</name>
+                  <description>4-bit data</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_5</name>
+                  <description>5-bit data</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_6</name>
+                  <description>6-bit data</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_7</name>
+                  <description>7-bit data</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_8</name>
+                  <description>8-bit data</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_9</name>
+                  <description>9-bit data</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_10</name>
+                  <description>10-bit data</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_11</name>
+                  <description>11-bit data</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_12</name>
+                  <description>12-bit data</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_13</name>
+                  <description>13-bit data</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_14</name>
+                  <description>14-bit data</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_15</name>
+                  <description>15-bit data</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_DSS_16</name>
+                  <description>16-bit data</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SSI_CR0_FRF</name>
+              <description>SSI Frame Format Select</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SSI_CR0_FRF_MOTO</name>
+                  <description>Freescale SPI Frame Format</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_FRF_TI</name>
+                  <description>Texas Instruments Synchronous Serial Frame Format</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CR0_FRF_NMW</name>
+                  <description>MICROWIRE Frame Format</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SSI_CR0_SPO</name>
+              <description>SSI Serial Clock Polarity</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SSI_CR0_SPH</name>
+              <description>SSI Serial Clock Phase</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SSI_CR0_SCR</name>
+              <description>SSI Serial Clock Rate</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CR1</name>
+          <description>SSI Control 1</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_CR1_LBM</name>
+              <description>SSI Loopback Mode</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SSI_CR1_SSE</name>
+              <description>SSI Synchronous Serial Port Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SSI_CR1_MS</name>
+              <description>SSI Master/Slave Select</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SSI_CR1_SOD</name>
+              <description>SSI Slave Mode Output Disable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SSI_CR1_EOT</name>
+              <description>End of Transmission</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DR</name>
+          <description>SSI Data</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_DR_DATA</name>
+              <description>SSI Receive/Transmit Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SR</name>
+          <description>SSI Status</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_SR_TFE</name>
+              <description>SSI Transmit FIFO Empty</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SSI_SR_TNF</name>
+              <description>SSI Transmit FIFO Not Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SSI_SR_RNE</name>
+              <description>SSI Receive FIFO Not Empty</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SSI_SR_RFF</name>
+              <description>SSI Receive FIFO Full</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SSI_SR_BSY</name>
+              <description>SSI Busy Bit</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CPSR</name>
+          <description>SSI Clock Prescale</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_CPSR_CPSDVSR</name>
+              <description>SSI Clock Prescale Divisor</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IM</name>
+          <description>SSI Interrupt Mask</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_IM_RORIM</name>
+              <description>SSI Receive Overrun Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SSI_IM_RTIM</name>
+              <description>SSI Receive Time-Out Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SSI_IM_RXIM</name>
+              <description>SSI Receive FIFO Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SSI_IM_TXIM</name>
+              <description>SSI Transmit FIFO Interrupt Mask</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>SSI Raw Interrupt Status</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_RIS_RORRIS</name>
+              <description>SSI Receive Overrun Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SSI_RIS_RTRIS</name>
+              <description>SSI Receive Time-Out Raw Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SSI_RIS_RXRIS</name>
+              <description>SSI Receive FIFO Raw Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SSI_RIS_TXRIS</name>
+              <description>SSI Transmit FIFO Raw Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>SSI Masked Interrupt Status</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_MIS_RORMIS</name>
+              <description>SSI Receive Overrun Masked Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SSI_MIS_RTMIS</name>
+              <description>SSI Receive Time-Out Masked Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SSI_MIS_RXMIS</name>
+              <description>SSI Receive FIFO Masked Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SSI_MIS_TXMIS</name>
+              <description>SSI Transmit FIFO Masked Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <description>SSI Interrupt Clear</description>
+          <addressOffset>0x00000020</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SSI_ICR_RORIC</name>
+              <description>SSI Receive Overrun Interrupt Clear</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SSI_ICR_RTIC</name>
+              <description>SSI Receive Time-Out Interrupt Clear</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DMACTL</name>
+          <description>SSI DMA Control</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_DMACTL_RXDMAE</name>
+              <description>Receive DMA Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SSI_DMACTL_TXDMAE</name>
+              <description>Transmit DMA Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CC</name>
+          <description>SSI Clock Configuration</description>
+          <addressOffset>0x00000FC8</addressOffset>
+          <fields>
+            <field>
+              <name>SSI_CC_CS</name>
+              <description>SSI Baud Clock Source</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SSI_CC_CS_SYSPLL</name>
+                  <description>Either the system clock (if the PLL bypass is in effect) or the PLL output (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSI_CC_CS_PIOSC</name>
+                  <description>PIOSC</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="SSI0">
+      <name>SSI1</name>
+      <prependToName>SSI1</prependToName>
+      <baseAddress>0x40009000</baseAddress>
+      <interrupt><name>SSI1</name><value>34</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SSI0">
+      <name>SSI2</name>
+      <prependToName>SSI2</prependToName>
+      <baseAddress>0x4000A000</baseAddress>
+      <interrupt><name>SSI2</name><value>57</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SSI0">
+      <name>SSI3</name>
+      <prependToName>SSI3</prependToName>
+      <baseAddress>0x4000B000</baseAddress>
+      <interrupt><name>SSI3</name><value>58</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>UART0</name>
+      <description>Register map for UART0 peripheral</description>
+      <groupName>UART</groupName>
+      <prependToName>UART0</prependToName>
+      <baseAddress>0x4000C000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>UART0</name><value>5</value></interrupt>
+      <registers>
+        <register>
+          <name>DR</name>
+          <description>UART Data</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>UART_DR_DATA</name>
+              <description>Data Transmitted or Received</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_DR_FE</name>
+              <description>UART Framing Error</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>UART_DR_PE</name>
+              <description>UART Parity Error</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>UART_DR_BE</name>
+              <description>UART Break Error</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>UART_DR_OE</name>
+              <description>UART Overrun Error</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RSR</name>
+          <description>UART Receive Status/Error Clear</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>UART_RSR_FE</name>
+              <description>UART Framing Error</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_RSR_PE</name>
+              <description>UART Parity Error</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>UART_RSR_BE</name>
+              <description>UART Break Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>UART_RSR_OE</name>
+              <description>UART Overrun Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ECR</name>
+          <description>UART Receive Status/Error Clear</description>
+          <alternateGroup>UART_ALT</alternateGroup>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>UART_ECR_DATA</name>
+              <description>Error Clear</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FR</name>
+          <description>UART Flag</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>UART_FR_CTS</name>
+              <description>Clear To Send</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_FR_BUSY</name>
+              <description>UART Busy</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>UART_FR_RXFE</name>
+              <description>UART Receive FIFO Empty</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>UART_FR_TXFF</name>
+              <description>UART Transmit FIFO Full</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>UART_FR_RXFF</name>
+              <description>UART Receive FIFO Full</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>UART_FR_TXFE</name>
+              <description>UART Transmit FIFO Empty</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ILPR</name>
+          <description>UART IrDA Low-Power Register</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>UART_ILPR_ILPDVSR</name>
+              <description>IrDA Low-Power Divisor</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IBRD</name>
+          <description>UART Integer Baud-Rate Divisor</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>UART_IBRD_DIVINT</name>
+              <description>Integer Baud-Rate Divisor</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FBRD</name>
+          <description>UART Fractional Baud-Rate Divisor</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>UART_FBRD_DIVFRAC</name>
+              <description>Fractional Baud-Rate Divisor</description>
+              <bitRange>[5:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCRH</name>
+          <description>UART Line Control</description>
+          <addressOffset>0x0000002C</addressOffset>
+          <fields>
+            <field>
+              <name>UART_LCRH_BRK</name>
+              <description>UART Send Break</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_LCRH_PEN</name>
+              <description>UART Parity Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>UART_LCRH_EPS</name>
+              <description>UART Even Parity Select</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>UART_LCRH_STP2</name>
+              <description>UART Two Stop Bits Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>UART_LCRH_FEN</name>
+              <description>UART Enable FIFOs</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>UART_LCRH_WLEN</name>
+              <description>UART Word Length</description>
+              <bitRange>[6:5]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UART_LCRH_WLEN_5</name>
+                  <description>5 bits (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_LCRH_WLEN_6</name>
+                  <description>6 bits</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_LCRH_WLEN_7</name>
+                  <description>7 bits</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_LCRH_WLEN_8</name>
+                  <description>8 bits</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>UART_LCRH_SPS</name>
+              <description>UART Stick Parity Select</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTL</name>
+          <description>UART Control</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>UART_CTL_UARTEN</name>
+              <description>UART Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_SIREN</name>
+              <description>UART SIR Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_SIRLP</name>
+              <description>UART SIR Low-Power Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_SMART</name>
+              <description>ISO 7816 Smart Card Support</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_EOT</name>
+              <description>End of Transmission</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_HSE</name>
+              <description>High-Speed Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_LBE</name>
+              <description>UART Loop Back Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_TXE</name>
+              <description>UART Transmit Enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_RXE</name>
+              <description>UART Receive Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_RTS</name>
+              <description>Request to Send</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_RTSEN</name>
+              <description>Enable Request to Send</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>UART_CTL_CTSEN</name>
+              <description>Enable Clear To Send</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IFLS</name>
+          <description>UART Interrupt FIFO Level Select</description>
+          <addressOffset>0x00000034</addressOffset>
+          <fields>
+            <field>
+              <name>UART_IFLS_TX</name>
+              <description>UART Transmit Interrupt FIFO Level Select</description>
+              <bitRange>[2:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UART_IFLS_TX1_8</name>
+                  <description>TX FIFO &amp;lt;= 1/8 full</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_TX2_8</name>
+                  <description>TX FIFO &amp;lt;= 1/4 full</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_TX4_8</name>
+                  <description>TX FIFO &amp;lt;= 1/2 full (default)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_TX6_8</name>
+                  <description>TX FIFO &amp;lt;= 3/4 full</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_TX7_8</name>
+                  <description>TX FIFO &amp;lt;= 7/8 full</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>UART_IFLS_RX</name>
+              <description>UART Receive Interrupt FIFO Level Select</description>
+              <bitRange>[5:3]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UART_IFLS_RX1_8</name>
+                  <description>RX FIFO >= 1/8 full</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_RX2_8</name>
+                  <description>RX FIFO >= 1/4 full</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_RX4_8</name>
+                  <description>RX FIFO >= 1/2 full (default)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_RX6_8</name>
+                  <description>RX FIFO >= 3/4 full</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_IFLS_RX7_8</name>
+                  <description>RX FIFO >= 7/8 full</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IM</name>
+          <description>UART Interrupt Mask</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>UART_IM_CTSMIM</name>
+              <description>UART Clear to Send Modem Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_RXIM</name>
+              <description>UART Receive Interrupt Mask</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_TXIM</name>
+              <description>UART Transmit Interrupt Mask</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_RTIM</name>
+              <description>UART Receive Time-Out Interrupt Mask</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_FEIM</name>
+              <description>UART Framing Error Interrupt Mask</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_PEIM</name>
+              <description>UART Parity Error Interrupt Mask</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_BEIM</name>
+              <description>UART Break Error Interrupt Mask</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_OEIM</name>
+              <description>UART Overrun Error Interrupt Mask</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>UART_IM_9BITIM</name>
+              <description>9-Bit Mode Interrupt Mask</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>UART Raw Interrupt Status</description>
+          <addressOffset>0x0000003C</addressOffset>
+          <fields>
+            <field>
+              <name>UART_RIS_CTSRIS</name>
+              <description>UART Clear to Send Modem Raw Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_RXRIS</name>
+              <description>UART Receive Raw Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_TXRIS</name>
+              <description>UART Transmit Raw Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_RTRIS</name>
+              <description>UART Receive Time-Out Raw Interrupt Status</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_FERIS</name>
+              <description>UART Framing Error Raw Interrupt Status</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_PERIS</name>
+              <description>UART Parity Error Raw Interrupt Status</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_BERIS</name>
+              <description>UART Break Error Raw Interrupt Status</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_OERIS</name>
+              <description>UART Overrun Error Raw Interrupt Status</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>UART_RIS_9BITRIS</name>
+              <description>9-Bit Mode Raw Interrupt Status</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>UART Masked Interrupt Status</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>UART_MIS_CTSMIS</name>
+              <description>UART Clear to Send Modem Masked Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_RXMIS</name>
+              <description>UART Receive Masked Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_TXMIS</name>
+              <description>UART Transmit Masked Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_RTMIS</name>
+              <description>UART Receive Time-Out Masked Interrupt Status</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_FEMIS</name>
+              <description>UART Framing Error Masked Interrupt Status</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_PEMIS</name>
+              <description>UART Parity Error Masked Interrupt Status</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_BEMIS</name>
+              <description>UART Break Error Masked Interrupt Status</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_OEMIS</name>
+              <description>UART Overrun Error Masked Interrupt Status</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>UART_MIS_9BITMIS</name>
+              <description>9-Bit Mode Masked Interrupt Status</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <description>UART Interrupt Clear</description>
+          <addressOffset>0x00000044</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UART_ICR_CTSMIC</name>
+              <description>UART Clear to Send Modem Interrupt Clear</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_RXIC</name>
+              <description>Receive Interrupt Clear</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_TXIC</name>
+              <description>Transmit Interrupt Clear</description>
+              <bitRange>[5:5]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_RTIC</name>
+              <description>Receive Time-Out Interrupt Clear</description>
+              <bitRange>[6:6]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_FEIC</name>
+              <description>Framing Error Interrupt Clear</description>
+              <bitRange>[7:7]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_PEIC</name>
+              <description>Parity Error Interrupt Clear</description>
+              <bitRange>[8:8]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_BEIC</name>
+              <description>Break Error Interrupt Clear</description>
+              <bitRange>[9:9]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_OEIC</name>
+              <description>Overrun Error Interrupt Clear</description>
+              <bitRange>[10:10]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>UART_ICR_9BITIC</name>
+              <description>9-Bit Mode Interrupt Clear</description>
+              <bitRange>[12:12]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DMACTL</name>
+          <description>UART DMA Control</description>
+          <addressOffset>0x00000048</addressOffset>
+          <fields>
+            <field>
+              <name>UART_DMACTL_RXDMAE</name>
+              <description>Receive DMA Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_DMACTL_TXDMAE</name>
+              <description>Transmit DMA Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>UART_DMACTL_DMAERR</name>
+              <description>DMA on Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_9BITADDR</name>
+          <description>UART 9-Bit Self Address</description>
+          <addressOffset>0x000000A4</addressOffset>
+          <fields>
+            <field>
+              <name>UART_9BITADDR_ADDR</name>
+              <description>Self Address for 9-Bit Mode</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_9BITADDR_9BITEN</name>
+              <description>Enable 9-Bit Mode</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_9BITAMASK</name>
+          <description>UART 9-Bit Self Address Mask</description>
+          <addressOffset>0x000000A8</addressOffset>
+          <fields>
+            <field>
+              <name>UART_9BITAMASK_MASK</name>
+              <description>Self Address Mask for 9-Bit Mode</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>UART Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>UART_PP_SC</name>
+              <description>Smart Card Support</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UART_PP_NB</name>
+              <description>9-Bit Support</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CC</name>
+          <description>UART Clock Configuration</description>
+          <addressOffset>0x00000FC8</addressOffset>
+          <fields>
+            <field>
+              <name>UART_CC_CS</name>
+              <description>UART Baud Clock Source</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UART_CC_CS_SYSCLK</name>
+                  <description>The system clock (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UART_CC_CS_PIOSC</name>
+                  <description>PIOSC</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="UART0">
+      <name>UART1</name>
+      <prependToName>UART1</prependToName>
+      <baseAddress>0x4000D000</baseAddress>
+      <interrupt><name>UART1</name><value>6</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="UART0">
+      <name>UART2</name>
+      <prependToName>UART2</prependToName>
+      <baseAddress>0x4000E000</baseAddress>
+      <interrupt><name>UART2</name><value>33</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="UART0">
+      <name>UART3</name>
+      <prependToName>UART3</prependToName>
+      <baseAddress>0x4000F000</baseAddress>
+      <interrupt><name>UART3</name><value>59</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="UART0">
+      <name>UART4</name>
+      <prependToName>UART4</prependToName>
+      <baseAddress>0x40010000</baseAddress>
+      <interrupt><name>UART4</name><value>60</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="UART0">
+      <name>UART5</name>
+      <prependToName>UART5</prependToName>
+      <baseAddress>0x40011000</baseAddress>
+      <interrupt><name>UART5</name><value>61</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="UART0">
+      <name>UART6</name>
+      <prependToName>UART6</prependToName>
+      <baseAddress>0x40012000</baseAddress>
+      <interrupt><name>UART6</name><value>62</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="UART0">
+      <name>UART7</name>
+      <prependToName>UART7</prependToName>
+      <baseAddress>0x40013000</baseAddress>
+      <interrupt><name>UART7</name><value>63</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>I2C0</name>
+      <description>Register map for I2C0 peripheral</description>
+      <groupName>I2C</groupName>
+      <prependToName>I2C0</prependToName>
+      <baseAddress>0x40020000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>I2C0</name><value>8</value></interrupt>
+      <registers>
+        <register>
+          <name>MSA</name>
+          <description>I2C Master Slave Address</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MSA_RS</name>
+              <description>Receive not send</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MSA_SA</name>
+              <description>I2C Slave Address</description>
+              <bitRange>[7:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MCS</name>
+          <description>I2C Master Control/Status</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MCS_RUN</name>
+              <description>I2C Master Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_START</name>
+              <description>Generate START</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_ADRACK</name>
+              <description>Acknowledge Address</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_ACK</name>
+              <description>Data Acknowledge Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_ARBLST</name>
+              <description>Arbitration Lost</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_IDLE</name>
+              <description>I2C Idle</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_CLKTO</name>
+              <description>Clock Timeout Error</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MCS</name>
+          <description>I2C Master Control/Status</description>
+          <alternateGroup>I2C0_ALT</alternateGroup>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MCS_BUSY</name>
+              <description>I2C Busy</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_ERROR</name>
+              <description>Error</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_STOP</name>
+              <description>Generate STOP</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_DATACK</name>
+              <description>Acknowledge Data</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_HS</name>
+              <description>High-Speed Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCS_BUSBSY</name>
+              <description>Bus Busy</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MDR</name>
+          <description>I2C Master Data</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MDR_DATA</name>
+              <description>Data Transferred</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MTPR</name>
+          <description>I2C Master Timer Period</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MTPR_TPR</name>
+              <description>Timer Period</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MTPR_HS</name>
+              <description>High-Speed Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIMR</name>
+          <description>I2C Master Interrupt Mask</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MIMR_IM</name>
+              <description>Master Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MIMR_CLKIM</name>
+              <description>Clock Timeout Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MRIS</name>
+          <description>I2C Master Raw Interrupt Status</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MRIS_RIS</name>
+              <description>Master Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MRIS_CLKRIS</name>
+              <description>Clock Timeout Raw Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MMIS</name>
+          <description>I2C Master Masked Interrupt Status</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MMIS_MIS</name>
+              <description>Masked Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MMIS_CLKMIS</name>
+              <description>Clock Timeout Masked Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MICR</name>
+          <description>I2C Master Interrupt Clear</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>I2C_MICR_IC</name>
+              <description>Master Interrupt Clear</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>I2C_MICR_CLKIC</name>
+              <description>Clock Timeout Interrupt Clear</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MCR</name>
+          <description>I2C Master Configuration</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MCR_LPBK</name>
+              <description>I2C Loopback</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCR_MFE</name>
+              <description>I2C Master Function Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCR_SFE</name>
+              <description>I2C Slave Function Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MCR_GFE</name>
+              <description>I2C Glitch Filter Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MCLKOCNT</name>
+          <description>I2C Master Clock Low Timeout Count</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MCLKOCNT_CNTL</name>
+              <description>I2C Master Count</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MBMON</name>
+          <description>I2C Master Bus Monitor</description>
+          <addressOffset>0x0000002C</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MBMON_SCL</name>
+              <description>I2C SCL Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_MBMON_SDA</name>
+              <description>I2C SDA Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MCR2</name>
+          <description>I2C Master Configuration 2</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_MCR2_GFPW</name>
+              <description>I2C Glitch Filter Pulse Width</description>
+              <bitRange>[6:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_BYPASS</name>
+                  <description>Bypass</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_1</name>
+                  <description>1 clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_2</name>
+                  <description>2 clocks</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_3</name>
+                  <description>3 clocks</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_4</name>
+                  <description>4 clocks</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_8</name>
+                  <description>8 clocks</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_16</name>
+                  <description>16 clocks</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MCR2_GFPW_32</name>
+                  <description>32 clocks</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SOAR</name>
+          <description>I2C Slave Own Address</description>
+          <addressOffset>0x00000800</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SOAR_OAR</name>
+              <description>I2C Slave Own Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCSR</name>
+          <description>I2C Slave Control/Status</description>
+          <addressOffset>0x00000804</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SCSR_RREQ</name>
+              <description>Receive Request</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SCSR_FBR</name>
+              <description>First Byte Received</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SCSR_OAR2SEL</name>
+              <description>OAR2 Address Matched</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCSR</name>
+          <description>I2C Slave Control/Status</description>
+          <alternateGroup>I2C0_ALT</alternateGroup>
+          <addressOffset>0x00000804</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SCSR_DA</name>
+              <description>Device Active</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SCSR_TREQ</name>
+              <description>Transmit Request</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SDR</name>
+          <description>I2C Slave Data</description>
+          <addressOffset>0x00000808</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SDR_DATA</name>
+              <description>Data for Transfer</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SIMR</name>
+          <description>I2C Slave Interrupt Mask</description>
+          <addressOffset>0x0000080C</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SIMR_DATAIM</name>
+              <description>Data Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SIMR_STARTIM</name>
+              <description>Start Condition Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SIMR_STOPIM</name>
+              <description>Stop Condition Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRIS</name>
+          <description>I2C Slave Raw Interrupt Status</description>
+          <addressOffset>0x00000810</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SRIS_DATARIS</name>
+              <description>Data Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SRIS_STARTRIS</name>
+              <description>Start Condition Raw Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SRIS_STOPRIS</name>
+              <description>Stop Condition Raw Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMIS</name>
+          <description>I2C Slave Masked Interrupt Status</description>
+          <addressOffset>0x00000814</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SMIS_DATAMIS</name>
+              <description>Data Masked Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SMIS_STARTMIS</name>
+              <description>Start Condition Masked Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SMIS_STOPMIS</name>
+              <description>Stop Condition Masked Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SICR</name>
+          <description>I2C Slave Interrupt Clear</description>
+          <addressOffset>0x00000818</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>I2C_SICR_DATAIC</name>
+              <description>Data Interrupt Clear</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>I2C_SICR_STARTIC</name>
+              <description>Start Condition Interrupt Clear</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>I2C_SICR_STOPIC</name>
+              <description>Stop Condition Interrupt Clear</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SOAR2</name>
+          <description>I2C Slave Own Address 2</description>
+          <addressOffset>0x0000081C</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SOAR2_OAR2</name>
+              <description>I2C Slave Own Address 2</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SOAR2_OAR2EN</name>
+              <description>I2C Slave Own Address 2 Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SACKCTL</name>
+          <description>I2C Slave ACK Control</description>
+          <addressOffset>0x00000820</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_SACKCTL_ACKOEN</name>
+              <description>I2C Slave ACK Override Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>I2C_SACKCTL_ACKOVAL</name>
+              <description>I2C Slave ACK Override Value</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>I2C Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_PP_HS</name>
+              <description>High-Speed Capable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PC</name>
+          <description>I2C Peripheral Configuration</description>
+          <addressOffset>0x00000FC4</addressOffset>
+          <fields>
+            <field>
+              <name>I2C_PC_HS</name>
+              <description>High-Speed Capable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="I2C0">
+      <name>I2C1</name>
+      <prependToName>I2C1</prependToName>
+      <baseAddress>0x40021000</baseAddress>
+      <interrupt><name>I2C1</name><value>37</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="I2C0">
+      <name>I2C2</name>
+      <prependToName>I2C2</prependToName>
+      <baseAddress>0x40022000</baseAddress>
+      <interrupt><name>I2C2</name><value>68</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="I2C0">
+      <name>I2C3</name>
+      <prependToName>I2C3</prependToName>
+      <baseAddress>0x40023000</baseAddress>
+      <interrupt><name>I2C3</name><value>69</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOE</name>
+      <prependToName>GPIOE</prependToName>
+      <baseAddress>0x40024000</baseAddress>
+      <interrupt><name>GPIOE</name><value>4</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOF</name>
+      <prependToName>GPIOF</prependToName>
+      <baseAddress>0x40025000</baseAddress>
+      <interrupt><name>GPIOF</name><value>30</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>PWM0</name>
+      <description>Register map for PWM0 peripheral</description>
+      <groupName>PWM</groupName>
+      <prependToName>PWM0</prependToName>
+      <baseAddress>0x40028000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>PWM0_0</name><value>10</value></interrupt>
+      <interrupt><name>PWM0_1</name><value>11</value></interrupt>
+      <interrupt><name>PWM0_2</name><value>12</value></interrupt>
+      <interrupt><name>PWM0_3</name><value>45</value></interrupt>
+      <interrupt><name>PWM0_FAULT</name><value>9</value></interrupt>
+      <registers>
+        <register>
+          <name>CTL</name>
+          <description>PWM Master Control</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_CTL_GLOBALSYNC0</name>
+              <description>Update PWM Generator 0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_CTL_GLOBALSYNC1</name>
+              <description>Update PWM Generator 1</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_CTL_GLOBALSYNC2</name>
+              <description>Update PWM Generator 2</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_CTL_GLOBALSYNC3</name>
+              <description>Update PWM Generator 3</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNC</name>
+          <description>PWM Time Base Sync</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_SYNC_SYNC0</name>
+              <description>Reset Generator 0 Counter</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_SYNC_SYNC1</name>
+              <description>Reset Generator 1 Counter</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_SYNC_SYNC2</name>
+              <description>Reset Generator 2 Counter</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_SYNC_SYNC3</name>
+              <description>Reset Generator 3 Counter</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENABLE</name>
+          <description>PWM Output Enable</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_ENABLE_PWM0EN</name>
+              <description>PWM0 Output Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ENABLE_PWM1EN</name>
+              <description>PWM1 Output Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ENABLE_PWM2EN</name>
+              <description>PWM2 Output Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ENABLE_PWM3EN</name>
+              <description>PWM3 Output Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ENABLE_PWM4EN</name>
+              <description>PWM4 Output Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ENABLE_PWM5EN</name>
+              <description>PWM5 Output Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ENABLE_PWM6EN</name>
+              <description>PWM6 Output Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ENABLE_PWM7EN</name>
+              <description>PWM7 Output Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INVERT</name>
+          <description>PWM Output Inversion</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_INVERT_PWM0INV</name>
+              <description>Invert PWM0 Signal</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INVERT_PWM1INV</name>
+              <description>Invert PWM1 Signal</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INVERT_PWM2INV</name>
+              <description>Invert PWM2 Signal</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INVERT_PWM3INV</name>
+              <description>Invert PWM3 Signal</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INVERT_PWM4INV</name>
+              <description>Invert PWM4 Signal</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INVERT_PWM5INV</name>
+              <description>Invert PWM5 Signal</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INVERT_PWM6INV</name>
+              <description>Invert PWM6 Signal</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INVERT_PWM7INV</name>
+              <description>Invert PWM7 Signal</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FAULT</name>
+          <description>PWM Output Fault</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_FAULT_FAULT0</name>
+              <description>PWM0 Fault</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULT_FAULT1</name>
+              <description>PWM1 Fault</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULT_FAULT2</name>
+              <description>PWM2 Fault</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULT_FAULT3</name>
+              <description>PWM3 Fault</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULT_FAULT4</name>
+              <description>PWM4 Fault</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULT_FAULT5</name>
+              <description>PWM5 Fault</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULT_FAULT6</name>
+              <description>PWM6 Fault</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULT_FAULT7</name>
+              <description>PWM7 Fault</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTEN</name>
+          <description>PWM Interrupt Enable</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_INTEN_INTPWM0</name>
+              <description>PWM0 Interrupt Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INTEN_INTPWM1</name>
+              <description>PWM1 Interrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INTEN_INTPWM2</name>
+              <description>PWM2 Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INTEN_INTPWM3</name>
+              <description>PWM3 Interrupt Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INTEN_INTFAULT0</name>
+              <description>Interrupt Fault 0</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>PWM_INTEN_INTFAULT1</name>
+              <description>Interrupt Fault 1</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>PWM Raw Interrupt Status</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_RIS_INTPWM0</name>
+              <description>PWM0 Interrupt Asserted</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_RIS_INTPWM1</name>
+              <description>PWM1 Interrupt Asserted</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_RIS_INTPWM2</name>
+              <description>PWM2 Interrupt Asserted</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_RIS_INTPWM3</name>
+              <description>PWM3 Interrupt Asserted</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_RIS_INTFAULT0</name>
+              <description>Interrupt Fault PWM 0</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>PWM_RIS_INTFAULT1</name>
+              <description>Interrupt Fault PWM 1</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ISC</name>
+          <description>PWM Interrupt Status and Clear</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_ISC_INTPWM0</name>
+              <description>PWM0 Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ISC_INTPWM1</name>
+              <description>PWM1 Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ISC_INTPWM2</name>
+              <description>PWM2 Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ISC_INTPWM3</name>
+              <description>PWM3 Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ISC_INTFAULT0</name>
+              <description>FAULT0 Interrupt Asserted</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>PWM_ISC_INTFAULT1</name>
+              <description>FAULT1 Interrupt Asserted</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>PWM Status</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_STATUS_FAULT0</name>
+              <description>Generator 0 Fault Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_STATUS_FAULT1</name>
+              <description>Generator 1 Fault Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FAULTVAL</name>
+          <description>PWM Fault Condition Value</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_FAULTVAL_PWM0</name>
+              <description>PWM0 Fault Value</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULTVAL_PWM1</name>
+              <description>PWM1 Fault Value</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULTVAL_PWM2</name>
+              <description>PWM2 Fault Value</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULTVAL_PWM3</name>
+              <description>PWM3 Fault Value</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULTVAL_PWM4</name>
+              <description>PWM4 Fault Value</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULTVAL_PWM5</name>
+              <description>PWM5 Fault Value</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULTVAL_PWM6</name>
+              <description>PWM6 Fault Value</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_FAULTVAL_PWM7</name>
+              <description>PWM7 Fault Value</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENUPD</name>
+          <description>PWM Enable Update</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_ENUPD_ENUPD0</name>
+              <description>PWM0 Enable Update Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD0_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD0_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD0_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_ENUPD_ENUPD1</name>
+              <description>PWM1 Enable Update Mode</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD1_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD1_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD1_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_ENUPD_ENUPD2</name>
+              <description>PWM2 Enable Update Mode</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD2_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD2_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD2_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_ENUPD_ENUPD3</name>
+              <description>PWM3 Enable Update Mode</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD3_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD3_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD3_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_ENUPD_ENUPD4</name>
+              <description>PWM4 Enable Update Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD4_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD4_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD4_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_ENUPD_ENUPD5</name>
+              <description>PWM5 Enable Update Mode</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD5_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD5_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD5_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_ENUPD_ENUPD6</name>
+              <description>PWM6 Enable Update Mode</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD6_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD6_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD6_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_ENUPD_ENUPD7</name>
+              <description>PWM7 Enable Update Mode</description>
+              <bitRange>[15:14]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD7_IMM</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD7_LSYNC</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_ENUPD_ENUPD7_GSYNC</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_CTL</name>
+          <description>PWM0 Control</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_CTL_ENABLE</name>
+              <description>PWM Block Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_MODE</name>
+              <description>Counter Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_DEBUG</name>
+              <description>Debug Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_LOADUPD</name>
+              <description>Load Register Update Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_CMPAUPD</name>
+              <description>Comparator A Update Mode</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_CMPBUPD</name>
+              <description>Comparator B Update Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_GENAUPD</name>
+              <description>PWMnGENA Update Mode</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_GENAUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_GENAUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_GENAUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_CTL_GENBUPD</name>
+              <description>PWMnGENB Update Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_GENBUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_GENBUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_GENBUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_CTL_DBCTLUPD</name>
+              <description>PWMnDBCTL Update Mode</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBCTLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBCTLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBCTLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_CTL_DBRISEUPD</name>
+              <description>PWMnDBRISE Update Mode</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBRISEUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBRISEUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBRISEUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_CTL_DBFALLUPD</name>
+              <description>Specifies the update mode for the PWMnDBFALL register</description>
+              <bitRange>[15:14]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBFALLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBFALLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_CTL_DBFALLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_CTL_FLTSRC</name>
+              <description>Fault Condition Source</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_MINFLTPER</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_CTL_LATCH</name>
+              <description>Latch Fault Input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_INTEN</name>
+          <description>PWM0 Interrupt and Trigger Enable</description>
+          <addressOffset>0x00000044</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_INTEN_INTCNTZERO</name>
+              <description>Interrupt for Counter=0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_INTCNTLOAD</name>
+              <description>Interrupt for Counter=Load</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_INTCMPAU</name>
+              <description>Interrupt for Counter=Comparator A Up</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_INTCMPAD</name>
+              <description>Interrupt for Counter=Comparator A Down</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_INTCMPBU</name>
+              <description>Interrupt for Counter=Comparator B Up</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_INTCMPBD</name>
+              <description>Interrupt for Counter=Comparator B Down</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_TRCNTZERO</name>
+              <description>Trigger for Counter=0</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_TRCNTLOAD</name>
+              <description>Trigger for Counter=Load</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_TRCMPAU</name>
+              <description>Trigger for Counter=Comparator A Up</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_TRCMPAD</name>
+              <description>Trigger for Counter=Comparator A Down</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_TRCMPBU</name>
+              <description>Trigger for Counter=Comparator B Up</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_INTEN_TRCMPBD</name>
+              <description>Trigger for Counter=Comparator B Down</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_RIS</name>
+          <description>PWM0 Raw Interrupt Status</description>
+          <addressOffset>0x00000048</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_RIS_INTCNTZERO</name>
+              <description>Counter=0 Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_RIS_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_RIS_INTCMPAU</name>
+              <description>Comparator A Up Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_RIS_INTCMPAD</name>
+              <description>Comparator A Down Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_RIS_INTCMPBU</name>
+              <description>Comparator B Up Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_RIS_INTCMPBD</name>
+              <description>Comparator B Down Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_ISC</name>
+          <description>PWM0 Interrupt Status and Clear</description>
+          <addressOffset>0x0000004C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_ISC_INTCNTZERO</name>
+              <description>Counter=0 Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_ISC_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_ISC_INTCMPAU</name>
+              <description>Comparator A Up Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_ISC_INTCMPAD</name>
+              <description>Comparator A Down Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_ISC_INTCMPBU</name>
+              <description>Comparator B Up Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_ISC_INTCMPBD</name>
+              <description>Comparator B Down Interrupt</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_LOAD</name>
+          <description>PWM0 Load</description>
+          <addressOffset>0x00000050</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_LOAD</name>
+              <description>Counter Load Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_COUNT</name>
+          <description>PWM0 Counter</description>
+          <addressOffset>0x00000054</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_COUNT</name>
+              <description>Counter Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_CMPA</name>
+          <description>PWM0 Compare A</description>
+          <addressOffset>0x00000058</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_CMPA</name>
+              <description>Comparator A Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_CMPB</name>
+          <description>PWM0 Compare B</description>
+          <addressOffset>0x0000005C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_CMPB</name>
+              <description>Comparator B Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_GENA</name>
+          <description>PWM0 Generator A Control</description>
+          <addressOffset>0x00000060</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_GENA_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENA_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENA_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENA_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENA_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENA_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENA_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_GENB</name>
+          <description>PWM0 Generator B Control</description>
+          <addressOffset>0x00000064</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_GENB_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENB_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENB_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENB_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENB_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_0_GENB_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_0_GENB_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_DBCTL</name>
+          <description>PWM0 Dead-Band Control</description>
+          <addressOffset>0x00000068</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_DBCTL_ENABLE</name>
+              <description>Dead-Band Generator Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_DBRISE</name>
+          <description>PWM0 Dead-Band Rising-Edge Delay</description>
+          <addressOffset>0x0000006C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_DBRISE_DELAY</name>
+              <description>Dead-Band Rise Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_DBFALL</name>
+          <description>PWM0 Dead-Band Falling-Edge-Delay</description>
+          <addressOffset>0x00000070</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_DBFALL_DELAY</name>
+              <description>Dead-Band Fall Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_FLTSRC0</name>
+          <description>PWM0 Fault Source 0</description>
+          <addressOffset>0x00000074</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_FLTSRC0_FAULT0</name>
+              <description>Fault0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC0_FAULT1</name>
+              <description>Fault1 Input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_FLTSRC1</name>
+          <description>PWM0 Fault Source 1</description>
+          <addressOffset>0x00000078</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP0</name>
+              <description>Digital Comparator 0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP1</name>
+              <description>Digital Comparator 1</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP2</name>
+              <description>Digital Comparator 2</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP3</name>
+              <description>Digital Comparator 3</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP4</name>
+              <description>Digital Comparator 4</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP5</name>
+              <description>Digital Comparator 5</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP6</name>
+              <description>Digital Comparator 6</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSRC1_DCMP7</name>
+              <description>Digital Comparator 7</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_MINFLTPER</name>
+          <description>PWM0 Minimum Fault Period</description>
+          <addressOffset>0x0000007C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_MINFLTPER</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_CTL</name>
+          <description>PWM1 Control</description>
+          <addressOffset>0x00000080</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_CTL_ENABLE</name>
+              <description>PWM Block Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_MODE</name>
+              <description>Counter Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_DEBUG</name>
+              <description>Debug Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_LOADUPD</name>
+              <description>Load Register Update Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_CMPAUPD</name>
+              <description>Comparator A Update Mode</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_CMPBUPD</name>
+              <description>Comparator B Update Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_GENAUPD</name>
+              <description>PWMnGENA Update Mode</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_GENAUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_GENAUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_GENAUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_CTL_GENBUPD</name>
+              <description>PWMnGENB Update Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_GENBUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_GENBUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_GENBUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_CTL_DBCTLUPD</name>
+              <description>PWMnDBCTL Update Mode</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBCTLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBCTLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBCTLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_CTL_DBRISEUPD</name>
+              <description>PWMnDBRISE Update Mode</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBRISEUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBRISEUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBRISEUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_CTL_DBFALLUPD</name>
+              <description>Specifies the update mode for the PWMnDBFALL register</description>
+              <bitRange>[15:14]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBFALLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBFALLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_CTL_DBFALLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_CTL_FLTSRC</name>
+              <description>Fault Condition Source</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_MINFLTPER</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_CTL_LATCH</name>
+              <description>Latch Fault Input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_INTEN</name>
+          <description>PWM1 Interrupt and Trigger Enable</description>
+          <addressOffset>0x00000084</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_INTEN_INTCNTZERO</name>
+              <description>Interrupt for Counter=0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_INTCNTLOAD</name>
+              <description>Interrupt for Counter=Load</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_INTCMPAU</name>
+              <description>Interrupt for Counter=Comparator A Up</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_INTCMPAD</name>
+              <description>Interrupt for Counter=Comparator A Down</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_INTCMPBU</name>
+              <description>Interrupt for Counter=Comparator B Up</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_INTCMPBD</name>
+              <description>Interrupt for Counter=Comparator B Down</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_TRCNTZERO</name>
+              <description>Trigger for Counter=0</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_TRCNTLOAD</name>
+              <description>Trigger for Counter=Load</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_TRCMPAU</name>
+              <description>Trigger for Counter=Comparator A Up</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_TRCMPAD</name>
+              <description>Trigger for Counter=Comparator A Down</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_TRCMPBU</name>
+              <description>Trigger for Counter=Comparator B Up</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_INTEN_TRCMPBD</name>
+              <description>Trigger for Counter=Comparator B Down</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_RIS</name>
+          <description>PWM1 Raw Interrupt Status</description>
+          <addressOffset>0x00000088</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_RIS_INTCNTZERO</name>
+              <description>Counter=0 Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_RIS_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_RIS_INTCMPAU</name>
+              <description>Comparator A Up Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_RIS_INTCMPAD</name>
+              <description>Comparator A Down Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_RIS_INTCMPBU</name>
+              <description>Comparator B Up Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_RIS_INTCMPBD</name>
+              <description>Comparator B Down Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_ISC</name>
+          <description>PWM1 Interrupt Status and Clear</description>
+          <addressOffset>0x0000008C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_ISC_INTCNTZERO</name>
+              <description>Counter=0 Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_ISC_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_ISC_INTCMPAU</name>
+              <description>Comparator A Up Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_ISC_INTCMPAD</name>
+              <description>Comparator A Down Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_ISC_INTCMPBU</name>
+              <description>Comparator B Up Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_ISC_INTCMPBD</name>
+              <description>Comparator B Down Interrupt</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_LOAD</name>
+          <description>PWM1 Load</description>
+          <addressOffset>0x00000090</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_LOAD_LOAD</name>
+              <description>Counter Load Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_COUNT</name>
+          <description>PWM1 Counter</description>
+          <addressOffset>0x00000094</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_COUNT_COUNT</name>
+              <description>Counter Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_CMPA</name>
+          <description>PWM1 Compare A</description>
+          <addressOffset>0x00000098</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_CMPA_COMPA</name>
+              <description>Comparator A Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_CMPB</name>
+          <description>PWM1 Compare B</description>
+          <addressOffset>0x0000009C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_CMPB_COMPB</name>
+              <description>Comparator B Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_GENA</name>
+          <description>PWM1 Generator A Control</description>
+          <addressOffset>0x000000A0</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_GENA_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENA_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENA_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENA_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENA_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENA_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENA_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_GENB</name>
+          <description>PWM1 Generator B Control</description>
+          <addressOffset>0x000000A4</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_GENB_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENB_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENB_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENB_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENB_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_1_GENB_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_1_GENB_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_DBCTL</name>
+          <description>PWM1 Dead-Band Control</description>
+          <addressOffset>0x000000A8</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_DBCTL_ENABLE</name>
+              <description>Dead-Band Generator Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_DBRISE</name>
+          <description>PWM1 Dead-Band Rising-Edge Delay</description>
+          <addressOffset>0x000000AC</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_DBRISE_RISEDELAY</name>
+              <description>Dead-Band Rise Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_DBFALL</name>
+          <description>PWM1 Dead-Band Falling-Edge-Delay</description>
+          <addressOffset>0x000000B0</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_DBFALL_FALLDELAY</name>
+              <description>Dead-Band Fall Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_FLTSRC0</name>
+          <description>PWM1 Fault Source 0</description>
+          <addressOffset>0x000000B4</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_FLTSRC0_FAULT0</name>
+              <description>Fault0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC0_FAULT1</name>
+              <description>Fault1 Input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_FLTSRC1</name>
+          <description>PWM1 Fault Source 1</description>
+          <addressOffset>0x000000B8</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP0</name>
+              <description>Digital Comparator 0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP1</name>
+              <description>Digital Comparator 1</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP2</name>
+              <description>Digital Comparator 2</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP3</name>
+              <description>Digital Comparator 3</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP4</name>
+              <description>Digital Comparator 4</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP5</name>
+              <description>Digital Comparator 5</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP6</name>
+              <description>Digital Comparator 6</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSRC1_DCMP7</name>
+              <description>Digital Comparator 7</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_MINFLTPER</name>
+          <description>PWM1 Minimum Fault Period</description>
+          <addressOffset>0x000000BC</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_MINFLTPER_MFP</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_CTL</name>
+          <description>PWM2 Control</description>
+          <addressOffset>0x000000C0</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_CTL_ENABLE</name>
+              <description>PWM Block Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_MODE</name>
+              <description>Counter Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_DEBUG</name>
+              <description>Debug Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_LOADUPD</name>
+              <description>Load Register Update Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_CMPAUPD</name>
+              <description>Comparator A Update Mode</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_CMPBUPD</name>
+              <description>Comparator B Update Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_GENAUPD</name>
+              <description>PWMnGENA Update Mode</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_GENAUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_GENAUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_GENAUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_CTL_GENBUPD</name>
+              <description>PWMnGENB Update Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_GENBUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_GENBUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_GENBUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_CTL_DBCTLUPD</name>
+              <description>PWMnDBCTL Update Mode</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBCTLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBCTLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBCTLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_CTL_DBRISEUPD</name>
+              <description>PWMnDBRISE Update Mode</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBRISEUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBRISEUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBRISEUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_CTL_DBFALLUPD</name>
+              <description>Specifies the update mode for the PWMnDBFALL register</description>
+              <bitRange>[15:14]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBFALLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBFALLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_CTL_DBFALLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_CTL_FLTSRC</name>
+              <description>Fault Condition Source</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_MINFLTPER</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_CTL_LATCH</name>
+              <description>Latch Fault Input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_INTEN</name>
+          <description>PWM2 Interrupt and Trigger Enable</description>
+          <addressOffset>0x000000C4</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_INTEN_INTCNTZERO</name>
+              <description>Interrupt for Counter=0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_INTCNTLOAD</name>
+              <description>Interrupt for Counter=Load</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_INTCMPAU</name>
+              <description>Interrupt for Counter=Comparator A Up</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_INTCMPAD</name>
+              <description>Interrupt for Counter=Comparator A Down</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_INTCMPBU</name>
+              <description>Interrupt for Counter=Comparator B Up</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_INTCMPBD</name>
+              <description>Interrupt for Counter=Comparator B Down</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_TRCNTZERO</name>
+              <description>Trigger for Counter=0</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_TRCNTLOAD</name>
+              <description>Trigger for Counter=Load</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_TRCMPAU</name>
+              <description>Trigger for Counter=Comparator A Up</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_TRCMPAD</name>
+              <description>Trigger for Counter=Comparator A Down</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_TRCMPBU</name>
+              <description>Trigger for Counter=Comparator B Up</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_INTEN_TRCMPBD</name>
+              <description>Trigger for Counter=Comparator B Down</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_RIS</name>
+          <description>PWM2 Raw Interrupt Status</description>
+          <addressOffset>0x000000C8</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_RIS_INTCNTZERO</name>
+              <description>Counter=0 Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_RIS_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_RIS_INTCMPAU</name>
+              <description>Comparator A Up Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_RIS_INTCMPAD</name>
+              <description>Comparator A Down Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_RIS_INTCMPBU</name>
+              <description>Comparator B Up Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_RIS_INTCMPBD</name>
+              <description>Comparator B Down Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_ISC</name>
+          <description>PWM2 Interrupt Status and Clear</description>
+          <addressOffset>0x000000CC</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_ISC_INTCNTZERO</name>
+              <description>Counter=0 Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_ISC_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_ISC_INTCMPAU</name>
+              <description>Comparator A Up Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_ISC_INTCMPAD</name>
+              <description>Comparator A Down Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_ISC_INTCMPBU</name>
+              <description>Comparator B Up Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_ISC_INTCMPBD</name>
+              <description>Comparator B Down Interrupt</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_LOAD</name>
+          <description>PWM2 Load</description>
+          <addressOffset>0x000000D0</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_LOAD_LOAD</name>
+              <description>Counter Load Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_COUNT</name>
+          <description>PWM2 Counter</description>
+          <addressOffset>0x000000D4</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_COUNT_COUNT</name>
+              <description>Counter Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_CMPA</name>
+          <description>PWM2 Compare A</description>
+          <addressOffset>0x000000D8</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_CMPA_COMPA</name>
+              <description>Comparator A Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_CMPB</name>
+          <description>PWM2 Compare B</description>
+          <addressOffset>0x000000DC</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_CMPB_COMPB</name>
+              <description>Comparator B Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_GENA</name>
+          <description>PWM2 Generator A Control</description>
+          <addressOffset>0x000000E0</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_GENA_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENA_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENA_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENA_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENA_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENA_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENA_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_GENB</name>
+          <description>PWM2 Generator B Control</description>
+          <addressOffset>0x000000E4</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_GENB_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENB_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENB_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENB_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENB_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_2_GENB_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_2_GENB_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_DBCTL</name>
+          <description>PWM2 Dead-Band Control</description>
+          <addressOffset>0x000000E8</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_DBCTL_ENABLE</name>
+              <description>Dead-Band Generator Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_DBRISE</name>
+          <description>PWM2 Dead-Band Rising-Edge Delay</description>
+          <addressOffset>0x000000EC</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_DBRISE_RISEDELAY</name>
+              <description>Dead-Band Rise Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_DBFALL</name>
+          <description>PWM2 Dead-Band Falling-Edge-Delay</description>
+          <addressOffset>0x000000F0</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_DBFALL_FALLDELAY</name>
+              <description>Dead-Band Fall Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_FLTSRC0</name>
+          <description>PWM2 Fault Source 0</description>
+          <addressOffset>0x000000F4</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_FLTSRC0_FAULT0</name>
+              <description>Fault0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC0_FAULT1</name>
+              <description>Fault1 Input</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_FLTSRC1</name>
+          <description>PWM2 Fault Source 1</description>
+          <addressOffset>0x000000F8</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP0</name>
+              <description>Digital Comparator 0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP1</name>
+              <description>Digital Comparator 1</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP2</name>
+              <description>Digital Comparator 2</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP3</name>
+              <description>Digital Comparator 3</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP4</name>
+              <description>Digital Comparator 4</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP5</name>
+              <description>Digital Comparator 5</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP6</name>
+              <description>Digital Comparator 6</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_2_FLTSRC1_DCMP7</name>
+              <description>Digital Comparator 7</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_MINFLTPER</name>
+          <description>PWM2 Minimum Fault Period</description>
+          <addressOffset>0x000000FC</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_2_MINFLTPER_MFP</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_CTL</name>
+          <description>PWM3 Control</description>
+          <addressOffset>0x00000100</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_CTL_ENABLE</name>
+              <description>PWM Block Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_MODE</name>
+              <description>Counter Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_DEBUG</name>
+              <description>Debug Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_LOADUPD</name>
+              <description>Load Register Update Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_CMPAUPD</name>
+              <description>Comparator A Update Mode</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_CMPBUPD</name>
+              <description>Comparator B Update Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_GENAUPD</name>
+              <description>PWMnGENA Update Mode</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_GENAUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_GENAUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_GENAUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_CTL_GENBUPD</name>
+              <description>PWMnGENB Update Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_GENBUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_GENBUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_GENBUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_CTL_DBCTLUPD</name>
+              <description>PWMnDBCTL Update Mode</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBCTLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBCTLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBCTLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_CTL_DBRISEUPD</name>
+              <description>PWMnDBRISE Update Mode</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBRISEUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBRISEUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBRISEUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_CTL_DBFALLUPD</name>
+              <description>Specifies the update mode for the PWMnDBFALL register</description>
+              <bitRange>[15:14]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBFALLUPD_I</name>
+                  <description>Immediate</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBFALLUPD_LS</name>
+                  <description>Locally Synchronized</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_CTL_DBFALLUPD_GS</name>
+                  <description>Globally Synchronized</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_CTL_FLTSRC</name>
+              <description>Fault Condition Source</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_MINFLTPER</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_CTL_LATCH</name>
+              <description>Latch Fault Input</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_INTEN</name>
+          <description>PWM3 Interrupt and Trigger Enable</description>
+          <addressOffset>0x00000104</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_INTEN_INTCNTZERO</name>
+              <description>Interrupt for Counter=0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_INTCNTLOAD</name>
+              <description>Interrupt for Counter=Load</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_INTCMPAU</name>
+              <description>Interrupt for Counter=Comparator A Up</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_INTCMPAD</name>
+              <description>Interrupt for Counter=Comparator A Down</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_INTCMPBU</name>
+              <description>Interrupt for Counter=Comparator B Up</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_INTCMPBD</name>
+              <description>Interrupt for Counter=Comparator B Down</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_TRCNTZERO</name>
+              <description>Trigger for Counter=0</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_TRCNTLOAD</name>
+              <description>Trigger for Counter=Load</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_TRCMPAU</name>
+              <description>Trigger for Counter=Comparator A Up</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_TRCMPAD</name>
+              <description>Trigger for Counter=Comparator A Down</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_TRCMPBU</name>
+              <description>Trigger for Counter=Comparator B Up</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_INTEN_TRCMPBD</name>
+              <description>Trigger for Counter=Comparator B Down</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_RIS</name>
+          <description>PWM3 Raw Interrupt Status</description>
+          <addressOffset>0x00000108</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_RIS_INTCNTZERO</name>
+              <description>Counter=0 Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_RIS_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_RIS_INTCMPAU</name>
+              <description>Comparator A Up Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_RIS_INTCMPAD</name>
+              <description>Comparator A Down Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_RIS_INTCMPBU</name>
+              <description>Comparator B Up Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_RIS_INTCMPBD</name>
+              <description>Comparator B Down Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_ISC</name>
+          <description>PWM3 Interrupt Status and Clear</description>
+          <addressOffset>0x0000010C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_ISC_INTCNTZERO</name>
+              <description>Counter=0 Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_ISC_INTCNTLOAD</name>
+              <description>Counter=Load Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_ISC_INTCMPAU</name>
+              <description>Comparator A Up Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_ISC_INTCMPAD</name>
+              <description>Comparator A Down Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_ISC_INTCMPBU</name>
+              <description>Comparator B Up Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_ISC_INTCMPBD</name>
+              <description>Comparator B Down Interrupt</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_LOAD</name>
+          <description>PWM3 Load</description>
+          <addressOffset>0x00000110</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_LOAD_LOAD</name>
+              <description>Counter Load Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_COUNT</name>
+          <description>PWM3 Counter</description>
+          <addressOffset>0x00000114</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_COUNT_COUNT</name>
+              <description>Counter Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_CMPA</name>
+          <description>PWM3 Compare A</description>
+          <addressOffset>0x00000118</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_CMPA_COMPA</name>
+              <description>Comparator A Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_CMPB</name>
+          <description>PWM3 Compare B</description>
+          <addressOffset>0x0000011C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_CMPB_COMPB</name>
+              <description>Comparator B Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_GENA</name>
+          <description>PWM3 Generator A Control</description>
+          <addressOffset>0x00000120</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_GENA_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENA_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENA_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENA_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENA_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENA_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENA_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_GENB</name>
+          <description>PWM3 Generator B Control</description>
+          <addressOffset>0x00000124</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_GENB_ACTZERO</name>
+              <description>Action for Counter=0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTZERO_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTZERO_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTZERO_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTZERO_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENB_ACTLOAD</name>
+              <description>Action for Counter=Load</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTLOAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTLOAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTLOAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTLOAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENB_ACTCMPAU</name>
+              <description>Action for Comparator A Up</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENB_ACTCMPAD</name>
+              <description>Action for Comparator A Down</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPAD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENB_ACTCMPBU</name>
+              <description>Action for Comparator B Up</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBU_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBU_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBU_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBU_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PWM_3_GENB_ACTCMPBD</name>
+              <description>Action for Comparator B Down</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBD_NONE</name>
+                  <description>Do nothing</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBD_INV</name>
+                  <description>Invert the output signal</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBD_ZERO</name>
+                  <description>Set the output signal to 0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWM_3_GENB_ACTCMPBD_ONE</name>
+                  <description>Set the output signal to 1</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_DBCTL</name>
+          <description>PWM3 Dead-Band Control</description>
+          <addressOffset>0x00000128</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_DBCTL_ENABLE</name>
+              <description>Dead-Band Generator Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_DBRISE</name>
+          <description>PWM3 Dead-Band Rising-Edge Delay</description>
+          <addressOffset>0x0000012C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_DBRISE_RISEDELAY</name>
+              <description>Dead-Band Rise Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_DBFALL</name>
+          <description>PWM3 Dead-Band Falling-Edge-Delay</description>
+          <addressOffset>0x00000130</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_DBFALL_FALLDELAY</name>
+              <description>Dead-Band Fall Delay</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_FLTSRC0</name>
+          <description>PWM3 Fault Source 0</description>
+          <addressOffset>0x00000134</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_FLTSRC0_FAULT0</name>
+              <description>Fault0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC0_FAULT1</name>
+              <description>Fault1</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_FLTSRC1</name>
+          <description>PWM3 Fault Source 1</description>
+          <addressOffset>0x00000138</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP0</name>
+              <description>Digital Comparator 0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP1</name>
+              <description>Digital Comparator 1</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP2</name>
+              <description>Digital Comparator 2</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP3</name>
+              <description>Digital Comparator 3</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP4</name>
+              <description>Digital Comparator 4</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP5</name>
+              <description>Digital Comparator 5</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP6</name>
+              <description>Digital Comparator 6</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>PWM_3_FLTSRC1_DCMP7</name>
+              <description>Digital Comparator 7</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_MINFLTPER</name>
+          <description>PWM3 Minimum Fault Period</description>
+          <addressOffset>0x0000013C</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_3_MINFLTPER_MFP</name>
+              <description>Minimum Fault Period</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_FLTSEN</name>
+          <description>PWM0 Fault Pin Logic Sense</description>
+          <addressOffset>0x00000800</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_0_FLTSEN_FAULT0</name>
+              <description>Fault0 Sense</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_0_FLTSEN_FAULT1</name>
+              <description>Fault1 Sense</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_FLTSTAT0</name>
+          <description>PWM0 Fault Status 0</description>
+          <addressOffset>0x00000804</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_0_FLTSTAT0_FAULT0</name>
+              <description>Fault Input 0</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT0_FAULT1</name>
+              <description>Fault Input 1</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_0_FLTSTAT1</name>
+          <description>PWM0 Fault Status 1</description>
+          <addressOffset>0x00000808</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP0</name>
+              <description>Digital Comparator 0 Trigger</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP1</name>
+              <description>Digital Comparator 1 Trigger</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP2</name>
+              <description>Digital Comparator 2 Trigger</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP3</name>
+              <description>Digital Comparator 3 Trigger</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP4</name>
+              <description>Digital Comparator 4 Trigger</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP5</name>
+              <description>Digital Comparator 5 Trigger</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP6</name>
+              <description>Digital Comparator 6 Trigger</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_0_FLTSTAT1_DCMP7</name>
+              <description>Digital Comparator 7 Trigger</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_FLTSEN</name>
+          <description>PWM1 Fault Pin Logic Sense</description>
+          <addressOffset>0x00000880</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_1_FLTSEN_FAULT0</name>
+              <description>Fault0 Sense</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_1_FLTSEN_FAULT1</name>
+              <description>Fault1 Sense</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_FLTSTAT0</name>
+          <description>PWM1 Fault Status 0</description>
+          <addressOffset>0x00000884</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_1_FLTSTAT0_FAULT0</name>
+              <description>Fault Input 0</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT0_FAULT1</name>
+              <description>Fault Input 1</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_1_FLTSTAT1</name>
+          <description>PWM1 Fault Status 1</description>
+          <addressOffset>0x00000888</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP0</name>
+              <description>Digital Comparator 0 Trigger</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP1</name>
+              <description>Digital Comparator 1 Trigger</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP2</name>
+              <description>Digital Comparator 2 Trigger</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP3</name>
+              <description>Digital Comparator 3 Trigger</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP4</name>
+              <description>Digital Comparator 4 Trigger</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP5</name>
+              <description>Digital Comparator 5 Trigger</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP6</name>
+              <description>Digital Comparator 6 Trigger</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_1_FLTSTAT1_DCMP7</name>
+              <description>Digital Comparator 7 Trigger</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_FLTSTAT0</name>
+          <description>PWM2 Fault Status 0</description>
+          <addressOffset>0x00000904</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_2_FLTSTAT0_FAULT0</name>
+              <description>Fault Input 0</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT0_FAULT1</name>
+              <description>Fault Input 1</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_2_FLTSTAT1</name>
+          <description>PWM2 Fault Status 1</description>
+          <addressOffset>0x00000908</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP0</name>
+              <description>Digital Comparator 0 Trigger</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP1</name>
+              <description>Digital Comparator 1 Trigger</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP2</name>
+              <description>Digital Comparator 2 Trigger</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP3</name>
+              <description>Digital Comparator 3 Trigger</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP4</name>
+              <description>Digital Comparator 4 Trigger</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP5</name>
+              <description>Digital Comparator 5 Trigger</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP6</name>
+              <description>Digital Comparator 6 Trigger</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_2_FLTSTAT1_DCMP7</name>
+              <description>Digital Comparator 7 Trigger</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_FLTSTAT0</name>
+          <description>PWM3 Fault Status 0</description>
+          <addressOffset>0x00000984</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_3_FLTSTAT0_FAULT0</name>
+              <description>Fault Input 0</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT0_FAULT1</name>
+              <description>Fault Input 1</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>_3_FLTSTAT1</name>
+          <description>PWM3 Fault Status 1</description>
+          <addressOffset>0x00000988</addressOffset>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP0</name>
+              <description>Digital Comparator 0 Trigger</description>
+              <bitRange>[0:0]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP1</name>
+              <description>Digital Comparator 1 Trigger</description>
+              <bitRange>[1:1]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP2</name>
+              <description>Digital Comparator 2 Trigger</description>
+              <bitRange>[2:2]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP3</name>
+              <description>Digital Comparator 3 Trigger</description>
+              <bitRange>[3:3]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP4</name>
+              <description>Digital Comparator 4 Trigger</description>
+              <bitRange>[4:4]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP5</name>
+              <description>Digital Comparator 5 Trigger</description>
+              <bitRange>[5:5]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP6</name>
+              <description>Digital Comparator 6 Trigger</description>
+              <bitRange>[6:6]</bitRange>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PWM_3_FLTSTAT1_DCMP7</name>
+              <description>Digital Comparator 7 Trigger</description>
+              <bitRange>[7:7]</bitRange>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>PWM Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>PWM_PP_GCNT</name>
+              <description>Generators</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>PWM_PP_FCNT</name>
+              <description>Fault Inputs</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>PWM_PP_ESYNC</name>
+              <description>Extended Synchronization</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>PWM_PP_EFAULT</name>
+              <description>Extended Fault</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>PWM_PP_ONE</name>
+              <description>One-Shot Mode</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PWM0">
+      <name>PWM1</name>
+      <prependToName>PWM1</prependToName>
+      <baseAddress>0x40029000</baseAddress>
+      <interrupt><name>PWM1_0</name><value>134</value></interrupt>
+      <interrupt><name>PWM1_1</name><value>135</value></interrupt>
+      <interrupt><name>PWM1_2</name><value>136</value></interrupt>
+      <interrupt><name>PWM1_3</name><value>137</value></interrupt>
+      <interrupt><name>PWM1_FAULT</name><value>138</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>QEI0</name>
+      <description>Register map for QEI0 peripheral</description>
+      <groupName>QEI</groupName>
+      <prependToName>QEI0</prependToName>
+      <baseAddress>0x4002C000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>QEI0</name><value>13</value></interrupt>
+      <registers>
+        <register>
+          <name>CTL</name>
+          <description>QEI Control</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_CTL_ENABLE</name>
+              <description>Enable QEI</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_SWAP</name>
+              <description>Swap Signals</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_SIGMODE</name>
+              <description>Signal Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_CAPMODE</name>
+              <description>Capture Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_RESMODE</name>
+              <description>Reset Mode</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_VELEN</name>
+              <description>Capture Velocity</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_VELDIV</name>
+              <description>Predivide Velocity</description>
+              <bitRange>[8:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_1</name>
+                  <description>QEI clock /1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_2</name>
+                  <description>QEI clock /2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_4</name>
+                  <description>QEI clock /4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_8</name>
+                  <description>QEI clock /8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_16</name>
+                  <description>QEI clock /16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_32</name>
+                  <description>QEI clock /32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_64</name>
+                  <description>QEI clock /64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>QEI_CTL_VELDIV_128</name>
+                  <description>QEI clock /128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>QEI_CTL_INVA</name>
+              <description>Invert PhA</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_INVB</name>
+              <description>Invert PhB</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_INVI</name>
+              <description>Invert Index Pulse</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_STALLEN</name>
+              <description>Stall QEI</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_FILTEN</name>
+              <description>Enable Input Filter</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>QEI_CTL_FILTCNT</name>
+              <description>Input Filter Prescale Count</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STAT</name>
+          <description>QEI Status</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_STAT_ERROR</name>
+              <description>Error Detected</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>QEI_STAT_DIRECTION</name>
+              <description>Direction of Rotation</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>POS</name>
+          <description>QEI Position</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_POS</name>
+              <description>Current Position Integrator Value</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MAXPOS</name>
+          <description>QEI Maximum Position</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_MAXPOS</name>
+              <description>Maximum Position Integrator Value</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LOAD</name>
+          <description>QEI Timer Load</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_LOAD</name>
+              <description>Velocity Timer Load Value</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TIME</name>
+          <description>QEI Timer</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_TIME</name>
+              <description>Velocity Timer Current Value</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>QEI Velocity Counter</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_COUNT</name>
+              <description>Velocity Pulse Count</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SPEED</name>
+          <description>QEI Velocity</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_SPEED</name>
+              <description>Velocity</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTEN</name>
+          <description>QEI Interrupt Enable</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_INTEN_INDEX</name>
+              <description>Index Pulse Detected Interrupt Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>QEI_INTEN_TIMER</name>
+              <description>Timer Expires Interrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>QEI_INTEN_DIR</name>
+              <description>Direction Change Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>QEI_INTEN_ERROR</name>
+              <description>Phase Error Interrupt Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>QEI Raw Interrupt Status</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_RIS_INDEX</name>
+              <description>Index Pulse Asserted</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>QEI_RIS_TIMER</name>
+              <description>Velocity Timer Expired</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>QEI_RIS_DIR</name>
+              <description>Direction Change Detected</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>QEI_RIS_ERROR</name>
+              <description>Phase Error Detected</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ISC</name>
+          <description>QEI Interrupt Status and Clear</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>QEI_ISC_INDEX</name>
+              <description>Index Pulse Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>QEI_ISC_TIMER</name>
+              <description>Velocity Timer Expired Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>QEI_ISC_DIR</name>
+              <description>Direction Change Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>QEI_ISC_ERROR</name>
+              <description>Phase Error Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="QEI0">
+      <name>QEI1</name>
+      <prependToName>QEI1</prependToName>
+      <baseAddress>0x4002D000</baseAddress>
+      <interrupt><name>QEI1</name><value>38</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>TIMER0</name>
+      <description>Register map for TIMER0 peripheral</description>
+      <groupName>TIMER</groupName>
+      <prependToName>TIMER0</prependToName>
+      <baseAddress>0x40030000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>TIMER0A</name><value>19</value></interrupt>
+      <interrupt><name>TIMER0B</name><value>20</value></interrupt>
+      <registers>
+        <register>
+          <name>CFG</name>
+          <description>GPTM Configuration</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_CFG</name>
+              <description>GPTM Configuration</description>
+              <bitRange>[2:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_CFG_32_BIT_TIMER</name>
+                  <description>32-bit timer configuration</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CFG_32_BIT_RTC</name>
+                  <description>32-bit real-time clock (RTC) counter configuration</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CFG_16_BIT</name>
+                  <description>16-bit timer configuration. The function is controlled by bits 1:0 of GPTMTAMR and GPTMTBMR</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAMR</name>
+          <description>GPTM Timer A Mode</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAMR_TAMR</name>
+              <description>GPTM Timer A Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_TAMR_TAMR_1_SHOT</name>
+                  <description>One-Shot Timer mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TAMR_TAMR_PERIOD</name>
+                  <description>Periodic Timer mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TAMR_TAMR_CAP</name>
+                  <description>Capture mode</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TACMR</name>
+              <description>GPTM Timer A Capture Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAAMS</name>
+              <description>GPTM Timer A Alternate Mode Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TACDIR</name>
+              <description>GPTM Timer A Count Direction</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAMIE</name>
+              <description>GPTM Timer A Match Interrupt Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAWOT</name>
+              <description>GPTM Timer A Wait-on-Trigger</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TASNAPS</name>
+              <description>GPTM Timer A Snap-Shot Mode</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAILD</name>
+              <description>GPTM Timer A Interval Load Write</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAPWMIE</name>
+              <description>GPTM Timer A PWM Interrupt Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAMRSU</name>
+              <description>GPTM Timer A Match Register Update</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAPLO</name>
+              <description>GPTM Timer A PWM Legacy Operation</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBMR</name>
+          <description>GPTM Timer B Mode</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBMR_TBMR</name>
+              <description>GPTM Timer B Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_TBMR_TBMR_1_SHOT</name>
+                  <description>One-Shot Timer mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TBMR_TBMR_PERIOD</name>
+                  <description>Periodic Timer mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TBMR_TBMR_CAP</name>
+                  <description>Capture mode</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBCMR</name>
+              <description>GPTM Timer B Capture Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBAMS</name>
+              <description>GPTM Timer B Alternate Mode Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBCDIR</name>
+              <description>GPTM Timer B Count Direction</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBMIE</name>
+              <description>GPTM Timer B Match Interrupt Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBWOT</name>
+              <description>GPTM Timer B Wait-on-Trigger</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBSNAPS</name>
+              <description>GPTM Timer B Snap-Shot Mode</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBILD</name>
+              <description>GPTM Timer B Interval Load Write</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBPWMIE</name>
+              <description>GPTM Timer B PWM Interrupt Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBMRSU</name>
+              <description>GPTM Timer B Match Register Update</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBPLO</name>
+              <description>GPTM Timer B PWM Legacy Operation</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTL</name>
+          <description>GPTM Control</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_CTL_TAEN</name>
+              <description>GPTM Timer A Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TASTALL</name>
+              <description>GPTM Timer A Stall Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TAEVENT</name>
+              <description>GPTM Timer A Event Mode</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TAEVENT_POS</name>
+                  <description>Positive edge</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TAEVENT_NEG</name>
+                  <description>Negative edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TAEVENT_BOTH</name>
+                  <description>Both edges</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_CTL_RTCEN</name>
+              <description>GPTM RTC Stall Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TAOTE</name>
+              <description>GPTM Timer A Output Trigger Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TAPWML</name>
+              <description>GPTM Timer A PWM Output Level</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBEN</name>
+              <description>GPTM Timer B Enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBSTALL</name>
+              <description>GPTM Timer B Stall Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBEVENT</name>
+              <description>GPTM Timer B Event Mode</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TBEVENT_POS</name>
+                  <description>Positive edge</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TBEVENT_NEG</name>
+                  <description>Negative edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TBEVENT_BOTH</name>
+                  <description>Both edges</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBOTE</name>
+              <description>GPTM Timer B Output Trigger Enable</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBPWML</name>
+              <description>GPTM Timer B PWM Output Level</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNC</name>
+          <description>GPTM Synchronize</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_SYNC_SYNCT0</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 0 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 0 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 0 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 0 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT1</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 1</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 1 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 1 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 1 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 1 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT2</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 2</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 2 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 2 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 2 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 2 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT3</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 3</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 3 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 3 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 3 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 3 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT4</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 4</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 4 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 4 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 4 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 4 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT5</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 5</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 5 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 5 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 5 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 5 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT0</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 0</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 0 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 0 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 0 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 0 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT1</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 1</description>
+              <bitRange>[15:14]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 1 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 1 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 1 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 1 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT2</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 2</description>
+              <bitRange>[17:16]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 2 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 2 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 2 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 2 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT3</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 3</description>
+              <bitRange>[19:18]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 3 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 3 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 3 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 3 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT4</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 4</description>
+              <bitRange>[21:20]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 4 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 4 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 4 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 4 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT5</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 5</description>
+              <bitRange>[23:22]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 5 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 5 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 5 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 5 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMR</name>
+          <description>GPTM Interrupt Mask</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_IMR_TATOIM</name>
+              <description>GPTM Timer A Time-Out Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CAMIM</name>
+              <description>GPTM Timer A Capture Mode Match Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CAEIM</name>
+              <description>GPTM Timer A Capture Mode Event Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_RTCIM</name>
+              <description>GPTM RTC Interrupt Mask</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_TAMIM</name>
+              <description>GPTM Timer A Match Interrupt Mask</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_TBTOIM</name>
+              <description>GPTM Timer B Time-Out Interrupt Mask</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CBMIM</name>
+              <description>GPTM Timer B Capture Mode Match Interrupt Mask</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CBEIM</name>
+              <description>GPTM Timer B Capture Mode Event Interrupt Mask</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_TBMIM</name>
+              <description>GPTM Timer B Match Interrupt Mask</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_WUEIM</name>
+              <description>GPTM Write Update Error Interrupt Mask</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>GPTM Raw Interrupt Status</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_RIS_TATORIS</name>
+              <description>GPTM Timer A Time-Out Raw Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CAMRIS</name>
+              <description>GPTM Timer A Capture Mode Match Raw Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CAERIS</name>
+              <description>GPTM Timer A Capture Mode Event Raw Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_RTCRIS</name>
+              <description>GPTM RTC Raw Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_TAMRIS</name>
+              <description>GPTM Timer A Match Raw Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_TBTORIS</name>
+              <description>GPTM Timer B Time-Out Raw Interrupt</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CBMRIS</name>
+              <description>GPTM Timer B Capture Mode Match Raw Interrupt</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CBERIS</name>
+              <description>GPTM Timer B Capture Mode Event Raw Interrupt</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_TBMRIS</name>
+              <description>GPTM Timer B Match Raw Interrupt</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_WUERIS</name>
+              <description>GPTM Write Update Error Raw Interrupt</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>GPTM Masked Interrupt Status</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_MIS_TATOMIS</name>
+              <description>GPTM Timer A Time-Out Masked Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CAMMIS</name>
+              <description>GPTM Timer A Capture Mode Match Masked Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CAEMIS</name>
+              <description>GPTM Timer A Capture Mode Event Masked Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_RTCMIS</name>
+              <description>GPTM RTC Masked Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_TAMMIS</name>
+              <description>GPTM Timer A Match Masked Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_TBTOMIS</name>
+              <description>GPTM Timer B Time-Out Masked Interrupt</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CBMMIS</name>
+              <description>GPTM Timer B Capture Mode Match Masked Interrupt</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CBEMIS</name>
+              <description>GPTM Timer B Capture Mode Event Masked Interrupt</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_TBMMIS</name>
+              <description>GPTM Timer B Match Masked Interrupt</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_WUEMIS</name>
+              <description>GPTM Write Update Error Masked Interrupt</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <description>GPTM Interrupt Clear</description>
+          <addressOffset>0x00000024</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>TIMER_ICR_TATOCINT</name>
+              <description>GPTM Timer A Time-Out Raw Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CAMCINT</name>
+              <description>GPTM Timer A Capture Mode Match Interrupt Clear</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CAECINT</name>
+              <description>GPTM Timer A Capture Mode Event Interrupt Clear</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_RTCCINT</name>
+              <description>GPTM RTC Interrupt Clear</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_TAMCINT</name>
+              <description>GPTM Timer A Match Interrupt Clear</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_TBTOCINT</name>
+              <description>GPTM Timer B Time-Out Interrupt Clear</description>
+              <bitRange>[8:8]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CBMCINT</name>
+              <description>GPTM Timer B Capture Mode Match Interrupt Clear</description>
+              <bitRange>[9:9]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CBECINT</name>
+              <description>GPTM Timer B Capture Mode Event Interrupt Clear</description>
+              <bitRange>[10:10]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_TBMCINT</name>
+              <description>GPTM Timer B Match Interrupt Clear</description>
+              <bitRange>[11:11]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_WUECINT</name>
+              <description>32/64-Bit GPTM Write Update Error Interrupt Clear</description>
+              <bitRange>[16:16]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAILR</name>
+          <description>GPTM Timer A Interval Load</description>
+          <addressOffset>0x00000028</addressOffset>
+        </register>
+        <register>
+          <name>TBILR</name>
+          <description>GPTM Timer B Interval Load</description>
+          <addressOffset>0x0000002C</addressOffset>
+        </register>
+        <register>
+          <name>TAMATCHR</name>
+          <description>GPTM Timer A Match</description>
+          <addressOffset>0x00000030</addressOffset>
+        </register>
+        <register>
+          <name>TBMATCHR</name>
+          <description>GPTM Timer B Match</description>
+          <addressOffset>0x00000034</addressOffset>
+        </register>
+        <register>
+          <name>TAPR</name>
+          <description>GPTM Timer A Prescale</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPR_TAPSR</name>
+              <description>GPTM Timer A Prescale</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAPR_TAPSRH</name>
+              <description>GPTM Timer A Prescale High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPR</name>
+          <description>GPTM Timer B Prescale</description>
+          <addressOffset>0x0000003C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPR_TBPSR</name>
+              <description>GPTM Timer B Prescale</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBPR_TBPSRH</name>
+              <description>GPTM Timer B Prescale High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAPMR</name>
+          <description>GPTM TimerA Prescale Match</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPMR_TAPSMR</name>
+              <description>GPTM TimerA Prescale Match</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAPMR_TAPSMRH</name>
+              <description>GPTM Timer A Prescale Match High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPMR</name>
+          <description>GPTM TimerB Prescale Match</description>
+          <addressOffset>0x00000044</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPMR_TBPSMR</name>
+              <description>GPTM TimerB Prescale Match</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBPMR_TBPSMRH</name>
+              <description>GPTM Timer B Prescale Match High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAR</name>
+          <description>GPTM Timer A</description>
+          <addressOffset>0x00000048</addressOffset>
+        </register>
+        <register>
+          <name>TBR</name>
+          <description>GPTM Timer B</description>
+          <addressOffset>0x0000004C</addressOffset>
+        </register>
+        <register>
+          <name>TAV</name>
+          <description>GPTM Timer A Value</description>
+          <addressOffset>0x00000050</addressOffset>
+        </register>
+        <register>
+          <name>TBV</name>
+          <description>GPTM Timer B Value</description>
+          <addressOffset>0x00000054</addressOffset>
+        </register>
+        <register>
+          <name>RTCPD</name>
+          <description>GPTM RTC Predivide</description>
+          <addressOffset>0x00000058</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_RTCPD_RTCPD</name>
+              <description>RTC Predivide Counter Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAPS</name>
+          <description>GPTM Timer A Prescale Snapshot</description>
+          <addressOffset>0x0000005C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPS_PSS</name>
+              <description>GPTM Timer A Prescaler Snapshot</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPS</name>
+          <description>GPTM Timer B Prescale Snapshot</description>
+          <addressOffset>0x00000060</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPS_PSS</name>
+              <description>GPTM Timer A Prescaler Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAPV</name>
+          <description>GPTM Timer A Prescale Value</description>
+          <addressOffset>0x00000064</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPV_PSV</name>
+              <description>GPTM Timer A Prescaler Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPV</name>
+          <description>GPTM Timer B Prescale Value</description>
+          <addressOffset>0x00000068</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPV_PSV</name>
+              <description>GPTM Timer B Prescaler Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>GPTM Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_PP_SIZE</name>
+              <description>Count Size</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_PP_SIZE_16</name>
+                  <description>Timer A and Timer B counters are 16 bits each with an 8-bit prescale counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_PP_SIZE_32</name>
+                  <description>Timer A and Timer B counters are 32 bits each with a 16-bit prescale counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>TIMER1</name>
+      <prependToName>TIMER1</prependToName>
+      <baseAddress>0x40031000</baseAddress>
+      <interrupt><name>TIMER1A</name><value>21</value></interrupt>
+      <interrupt><name>TIMER1B</name><value>22</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>TIMER2</name>
+      <prependToName>TIMER2</prependToName>
+      <baseAddress>0x40032000</baseAddress>
+      <interrupt><name>TIMER2A</name><value>23</value></interrupt>
+      <interrupt><name>TIMER2B</name><value>24</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>TIMER3</name>
+      <prependToName>TIMER3</prependToName>
+      <baseAddress>0x40033000</baseAddress>
+      <interrupt><name>TIMER3A</name><value>35</value></interrupt>
+      <interrupt><name>TIMER3B</name><value>36</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>TIMER4</name>
+      <prependToName>TIMER4</prependToName>
+      <baseAddress>0x40034000</baseAddress>
+      <interrupt><name>TIMER4A</name><value>70</value></interrupt>
+      <interrupt><name>TIMER4B</name><value>71</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>TIMER5</name>
+      <prependToName>TIMER5</prependToName>
+      <baseAddress>0x40035000</baseAddress>
+      <interrupt><name>TIMER5A</name><value>92</value></interrupt>
+      <interrupt><name>TIMER5B</name><value>93</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>WTIMER0</name>
+      <description>Register map for WTIMER0 peripheral</description>
+      <groupName>TIMER</groupName>
+      <prependToName>WTIMER0</prependToName>
+      <baseAddress>0x40036000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>WTIMER0A</name><value>94</value></interrupt>
+      <interrupt><name>WTIMER0B</name><value>95</value></interrupt>
+      <registers>
+        <register>
+          <name>CFG</name>
+          <description>GPTM Configuration</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_CFG</name>
+              <description>GPTM Configuration</description>
+              <bitRange>[2:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_CFG_32_BIT_TIMER</name>
+                  <description>32-bit timer configuration</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CFG_32_BIT_RTC</name>
+                  <description>32-bit real-time clock (RTC) counter configuration</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CFG_16_BIT</name>
+                  <description>16-bit timer configuration. The function is controlled by bits 1:0 of GPTMTAMR and GPTMTBMR</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAMR</name>
+          <description>GPTM Timer A Mode</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAMR_TAMR</name>
+              <description>GPTM Timer A Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_TAMR_TAMR_1_SHOT</name>
+                  <description>One-Shot Timer mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TAMR_TAMR_PERIOD</name>
+                  <description>Periodic Timer mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TAMR_TAMR_CAP</name>
+                  <description>Capture mode</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TACMR</name>
+              <description>GPTM Timer A Capture Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAAMS</name>
+              <description>GPTM Timer A Alternate Mode Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TACDIR</name>
+              <description>GPTM Timer A Count Direction</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAMIE</name>
+              <description>GPTM Timer A Match Interrupt Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAWOT</name>
+              <description>GPTM Timer A Wait-on-Trigger</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TASNAPS</name>
+              <description>GPTM Timer A Snap-Shot Mode</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAILD</name>
+              <description>GPTM Timer A Interval Load Write</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAPWMIE</name>
+              <description>GPTM Timer A PWM Interrupt Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAMRSU</name>
+              <description>GPTM Timer A Match Register Update</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAMR_TAPLO</name>
+              <description>GPTM Timer A PWM Legacy Operation</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBMR</name>
+          <description>GPTM Timer B Mode</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBMR_TBMR</name>
+              <description>GPTM Timer B Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_TBMR_TBMR_1_SHOT</name>
+                  <description>One-Shot Timer mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TBMR_TBMR_PERIOD</name>
+                  <description>Periodic Timer mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_TBMR_TBMR_CAP</name>
+                  <description>Capture mode</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBCMR</name>
+              <description>GPTM Timer B Capture Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBAMS</name>
+              <description>GPTM Timer B Alternate Mode Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBCDIR</name>
+              <description>GPTM Timer B Count Direction</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBMIE</name>
+              <description>GPTM Timer B Match Interrupt Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBWOT</name>
+              <description>GPTM Timer B Wait-on-Trigger</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBSNAPS</name>
+              <description>GPTM Timer B Snap-Shot Mode</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBILD</name>
+              <description>GPTM Timer B Interval Load Write</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBPWMIE</name>
+              <description>GPTM Timer B PWM Interrupt Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBMRSU</name>
+              <description>GPTM Timer B Match Register Update</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBMR_TBPLO</name>
+              <description>GPTM Timer B PWM Legacy Operation</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTL</name>
+          <description>GPTM Control</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_CTL_TAEN</name>
+              <description>GPTM Timer A Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TASTALL</name>
+              <description>GPTM Timer A Stall Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TAEVENT</name>
+              <description>GPTM Timer A Event Mode</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TAEVENT_POS</name>
+                  <description>Positive edge</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TAEVENT_NEG</name>
+                  <description>Negative edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TAEVENT_BOTH</name>
+                  <description>Both edges</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_CTL_RTCEN</name>
+              <description>GPTM RTC Stall Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TAOTE</name>
+              <description>GPTM Timer A Output Trigger Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TAPWML</name>
+              <description>GPTM Timer A PWM Output Level</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBEN</name>
+              <description>GPTM Timer B Enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBSTALL</name>
+              <description>GPTM Timer B Stall Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBEVENT</name>
+              <description>GPTM Timer B Event Mode</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TBEVENT_POS</name>
+                  <description>Positive edge</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TBEVENT_NEG</name>
+                  <description>Negative edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_CTL_TBEVENT_BOTH</name>
+                  <description>Both edges</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBOTE</name>
+              <description>GPTM Timer B Output Trigger Enable</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_CTL_TBPWML</name>
+              <description>GPTM Timer B PWM Output Level</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNC</name>
+          <description>GPTM Synchronize</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_SYNC_SYNCT0</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 0</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 0 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 0 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 0 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT0_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 0 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT1</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 1</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 1 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 1 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 1 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT1_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 1 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT2</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 2</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 2 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 2 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 2 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT2_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 2 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT3</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 3</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 3 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 3 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 3 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT3_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 3 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT4</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 4</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 4 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 4 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 4 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT4_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 4 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCT5</name>
+              <description>Synchronize GPTM 16/32-Bit Timer 5</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_NONE</name>
+                  <description>GPTM 16/32-Bit Timer 5 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_TA</name>
+                  <description>A timeout event for Timer A of GPTM 16/32-Bit Timer 5 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_TB</name>
+                  <description>A timeout event for Timer B of GPTM 16/32-Bit Timer 5 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCT5_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 16/32-Bit Timer 5 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT0</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 0</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 0 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 0 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 0 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT0_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 0 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT1</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 1</description>
+              <bitRange>[15:14]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 1 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 1 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 1 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT1_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 1 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT2</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 2</description>
+              <bitRange>[17:16]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 2 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 2 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 2 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT2_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 2 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT3</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 3</description>
+              <bitRange>[19:18]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 3 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 3 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 3 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT3_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 3 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT4</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 4</description>
+              <bitRange>[21:20]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 4 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 4 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 4 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT4_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 4 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TIMER_SYNC_SYNCWT5</name>
+              <description>Synchronize GPTM 32/64-Bit Timer 5</description>
+              <bitRange>[23:22]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_NONE</name>
+                  <description>GPTM 32/64-Bit Timer 5 is not affected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_TA</name>
+                  <description>A timeout event for Timer A of GPTM 32/64-Bit Timer 5 is triggered</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_TB</name>
+                  <description>A timeout event for Timer B of GPTM 32/64-Bit Timer 5 is triggered</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_SYNC_SYNCWT5_TATB</name>
+                  <description>A timeout event for both Timer A and Timer B of GPTM 32/64-Bit Timer 5 is triggered</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMR</name>
+          <description>GPTM Interrupt Mask</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_IMR_TATOIM</name>
+              <description>GPTM Timer A Time-Out Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CAMIM</name>
+              <description>GPTM Timer A Capture Mode Match Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CAEIM</name>
+              <description>GPTM Timer A Capture Mode Event Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_RTCIM</name>
+              <description>GPTM RTC Interrupt Mask</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_TAMIM</name>
+              <description>GPTM Timer A Match Interrupt Mask</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_TBTOIM</name>
+              <description>GPTM Timer B Time-Out Interrupt Mask</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CBMIM</name>
+              <description>GPTM Timer B Capture Mode Match Interrupt Mask</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_CBEIM</name>
+              <description>GPTM Timer B Capture Mode Event Interrupt Mask</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_TBMIM</name>
+              <description>GPTM Timer B Match Interrupt Mask</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_IMR_WUEIM</name>
+              <description>GPTM Write Update Error Interrupt Mask</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>GPTM Raw Interrupt Status</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_RIS_TATORIS</name>
+              <description>GPTM Timer A Time-Out Raw Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CAMRIS</name>
+              <description>GPTM Timer A Capture Mode Match Raw Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CAERIS</name>
+              <description>GPTM Timer A Capture Mode Event Raw Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_RTCRIS</name>
+              <description>GPTM RTC Raw Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_TAMRIS</name>
+              <description>GPTM Timer A Match Raw Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_TBTORIS</name>
+              <description>GPTM Timer B Time-Out Raw Interrupt</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CBMRIS</name>
+              <description>GPTM Timer B Capture Mode Match Raw Interrupt</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_CBERIS</name>
+              <description>GPTM Timer B Capture Mode Event Raw Interrupt</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_TBMRIS</name>
+              <description>GPTM Timer B Match Raw Interrupt</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_RIS_WUERIS</name>
+              <description>GPTM Write Update Error Raw Interrupt</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>GPTM Masked Interrupt Status</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_MIS_TATOMIS</name>
+              <description>GPTM Timer A Time-Out Masked Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CAMMIS</name>
+              <description>GPTM Timer A Capture Mode Match Masked Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CAEMIS</name>
+              <description>GPTM Timer A Capture Mode Event Masked Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_RTCMIS</name>
+              <description>GPTM RTC Masked Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_TAMMIS</name>
+              <description>GPTM Timer A Match Masked Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_TBTOMIS</name>
+              <description>GPTM Timer B Time-Out Masked Interrupt</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CBMMIS</name>
+              <description>GPTM Timer B Capture Mode Match Masked Interrupt</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_CBEMIS</name>
+              <description>GPTM Timer B Capture Mode Event Masked Interrupt</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_TBMMIS</name>
+              <description>GPTM Timer B Match Masked Interrupt</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_MIS_WUEMIS</name>
+              <description>GPTM Write Update Error Masked Interrupt</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ICR</name>
+          <description>GPTM Interrupt Clear</description>
+          <addressOffset>0x00000024</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>TIMER_ICR_TATOCINT</name>
+              <description>GPTM Timer A Time-Out Raw Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CAMCINT</name>
+              <description>GPTM Timer A Capture Mode Match Interrupt Clear</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CAECINT</name>
+              <description>GPTM Timer A Capture Mode Event Interrupt Clear</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_RTCCINT</name>
+              <description>GPTM RTC Interrupt Clear</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_TAMCINT</name>
+              <description>GPTM Timer A Match Interrupt Clear</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_TBTOCINT</name>
+              <description>GPTM Timer B Time-Out Interrupt Clear</description>
+              <bitRange>[8:8]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CBMCINT</name>
+              <description>GPTM Timer B Capture Mode Match Interrupt Clear</description>
+              <bitRange>[9:9]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_CBECINT</name>
+              <description>GPTM Timer B Capture Mode Event Interrupt Clear</description>
+              <bitRange>[10:10]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_TBMCINT</name>
+              <description>GPTM Timer B Match Interrupt Clear</description>
+              <bitRange>[11:11]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>TIMER_ICR_WUECINT</name>
+              <description>32/64-Bit GPTM Write Update Error Interrupt Clear</description>
+              <bitRange>[16:16]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAILR</name>
+          <description>GPTM Timer A Interval Load</description>
+          <addressOffset>0x00000028</addressOffset>
+        </register>
+        <register>
+          <name>TBILR</name>
+          <description>GPTM Timer B Interval Load</description>
+          <addressOffset>0x0000002C</addressOffset>
+        </register>
+        <register>
+          <name>TAMATCHR</name>
+          <description>GPTM Timer A Match</description>
+          <addressOffset>0x00000030</addressOffset>
+        </register>
+        <register>
+          <name>TBMATCHR</name>
+          <description>GPTM Timer B Match</description>
+          <addressOffset>0x00000034</addressOffset>
+        </register>
+        <register>
+          <name>TAPR</name>
+          <description>GPTM Timer A Prescale</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPR_TAPSR</name>
+              <description>GPTM Timer A Prescale</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAPR_TAPSRH</name>
+              <description>GPTM Timer A Prescale High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPR</name>
+          <description>GPTM Timer B Prescale</description>
+          <addressOffset>0x0000003C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPR_TBPSR</name>
+              <description>GPTM Timer B Prescale</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBPR_TBPSRH</name>
+              <description>GPTM Timer B Prescale High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAPMR</name>
+          <description>GPTM TimerA Prescale Match</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPMR_TAPSMR</name>
+              <description>GPTM TimerA Prescale Match</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TAPMR_TAPSMRH</name>
+              <description>GPTM Timer A Prescale Match High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPMR</name>
+          <description>GPTM TimerB Prescale Match</description>
+          <addressOffset>0x00000044</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPMR_TBPSMR</name>
+              <description>GPTM TimerB Prescale Match</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>TIMER_TBPMR_TBPSMRH</name>
+              <description>GPTM Timer B Prescale Match High Byte</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAR</name>
+          <description>GPTM Timer A</description>
+          <addressOffset>0x00000048</addressOffset>
+        </register>
+        <register>
+          <name>TBR</name>
+          <description>GPTM Timer B</description>
+          <addressOffset>0x0000004C</addressOffset>
+        </register>
+        <register>
+          <name>TAV</name>
+          <description>GPTM Timer A Value</description>
+          <addressOffset>0x00000050</addressOffset>
+        </register>
+        <register>
+          <name>TBV</name>
+          <description>GPTM Timer B Value</description>
+          <addressOffset>0x00000054</addressOffset>
+        </register>
+        <register>
+          <name>RTCPD</name>
+          <description>GPTM RTC Predivide</description>
+          <addressOffset>0x00000058</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_RTCPD_RTCPD</name>
+              <description>RTC Predivide Counter Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAPS</name>
+          <description>GPTM Timer A Prescale Snapshot</description>
+          <addressOffset>0x0000005C</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPS_PSS</name>
+              <description>GPTM Timer A Prescaler Snapshot</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPS</name>
+          <description>GPTM Timer B Prescale Snapshot</description>
+          <addressOffset>0x00000060</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPS_PSS</name>
+              <description>GPTM Timer A Prescaler Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TAPV</name>
+          <description>GPTM Timer A Prescale Value</description>
+          <addressOffset>0x00000064</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TAPV_PSV</name>
+              <description>GPTM Timer A Prescaler Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TBPV</name>
+          <description>GPTM Timer B Prescale Value</description>
+          <addressOffset>0x00000068</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_TBPV_PSV</name>
+              <description>GPTM Timer B Prescaler Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>GPTM Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>TIMER_PP_SIZE</name>
+              <description>Count Size</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>TIMER_PP_SIZE_16</name>
+                  <description>Timer A and Timer B counters are 16 bits each with an 8-bit prescale counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TIMER_PP_SIZE_32</name>
+                  <description>Timer A and Timer B counters are 32 bits each with a 16-bit prescale counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>WTIMER1</name>
+      <prependToName>WTIMER1</prependToName>
+      <baseAddress>0x40037000</baseAddress>
+      <interrupt><name>WTIMER1A</name><value>96</value></interrupt>
+      <interrupt><name>WTIMER1B</name><value>97</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>ADC0</name>
+      <description>Register map for ADC0 peripheral</description>
+      <groupName>ADC</groupName>
+      <prependToName>ADC0</prependToName>
+      <baseAddress>0x40038000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>ADC0SS0</name><value>14</value></interrupt>
+      <interrupt><name>ADC0SS1</name><value>15</value></interrupt>
+      <interrupt><name>ADC0SS2</name><value>16</value></interrupt>
+      <interrupt><name>ADC0SS3</name><value>17</value></interrupt>
+      <registers>
+        <register>
+          <name>ACTSS</name>
+          <description>ADC Active Sample Sequencer</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_ACTSS_ASEN0</name>
+              <description>ADC SS0 Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ACTSS_ASEN1</name>
+              <description>ADC SS1 Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ACTSS_ASEN2</name>
+              <description>ADC SS2 Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ACTSS_ASEN3</name>
+              <description>ADC SS3 Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ACTSS_BUSY</name>
+              <description>ADC Busy</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>ADC Raw Interrupt Status</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_RIS_INR0</name>
+              <description>SS0 Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_RIS_INR1</name>
+              <description>SS1 Raw Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_RIS_INR2</name>
+              <description>SS2 Raw Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_RIS_INR3</name>
+              <description>SS3 Raw Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_RIS_INRDC</name>
+              <description>Digital Comparator Raw Interrupt Status</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IM</name>
+          <description>ADC Interrupt Mask</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_IM_MASK0</name>
+              <description>SS0 Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_IM_MASK1</name>
+              <description>SS1 Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_IM_MASK2</name>
+              <description>SS2 Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_IM_MASK3</name>
+              <description>SS3 Interrupt Mask</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_IM_DCONSS0</name>
+              <description>Digital Comparator Interrupt on SS0</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>ADC_IM_DCONSS1</name>
+              <description>Digital Comparator Interrupt on SS1</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>ADC_IM_DCONSS2</name>
+              <description>Digital Comparator Interrupt on SS2</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>ADC_IM_DCONSS3</name>
+              <description>Digital Comparator Interrupt on SS3</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ISC</name>
+          <description>ADC Interrupt Status and Clear</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_ISC_IN0</name>
+              <description>SS0 Interrupt Status and Clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ISC_IN1</name>
+              <description>SS1 Interrupt Status and Clear</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ISC_IN2</name>
+              <description>SS2 Interrupt Status and Clear</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ISC_IN3</name>
+              <description>SS3 Interrupt Status and Clear</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ISC_DCINSS0</name>
+              <description>Digital Comparator Interrupt Status on SS0</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ISC_DCINSS1</name>
+              <description>Digital Comparator Interrupt Status on SS1</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ISC_DCINSS2</name>
+              <description>Digital Comparator Interrupt Status on SS2</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>ADC_ISC_DCINSS3</name>
+              <description>Digital Comparator Interrupt Status on SS3</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSTAT</name>
+          <description>ADC Overflow Status</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_OSTAT_OV0</name>
+              <description>SS0 FIFO Overflow</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_OSTAT_OV1</name>
+              <description>SS1 FIFO Overflow</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_OSTAT_OV2</name>
+              <description>SS2 FIFO Overflow</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_OSTAT_OV3</name>
+              <description>SS3 FIFO Overflow</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EMUX</name>
+          <description>ADC Event Multiplexer Select</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_EMUX_EM0</name>
+              <description>SS0 Trigger Select</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_PROCESSOR</name>
+                  <description>Processor (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_COMP0</name>
+                  <description>Analog Comparator 0</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_COMP1</name>
+                  <description>Analog Comparator 1</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_EXTERNAL</name>
+                  <description>External (GPIO PB4)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_TIMER</name>
+                  <description>Timer</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_PWM0</name>
+                  <description>PWM0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_PWM1</name>
+                  <description>PWM1</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_PWM2</name>
+                  <description>PWM2</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_PWM3</name>
+                  <description>PWM3</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM0_ALWAYS</name>
+                  <description>Always (continuously sample)</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_EMUX_EM1</name>
+              <description>SS1 Trigger Select</description>
+              <bitRange>[7:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_PROCESSOR</name>
+                  <description>Processor (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_COMP0</name>
+                  <description>Analog Comparator 0</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_COMP1</name>
+                  <description>Analog Comparator 1</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_EXTERNAL</name>
+                  <description>External (GPIO PB4)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_TIMER</name>
+                  <description>Timer</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_PWM0</name>
+                  <description>PWM0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_PWM1</name>
+                  <description>PWM1</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_PWM2</name>
+                  <description>PWM2</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_PWM3</name>
+                  <description>PWM3</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM1_ALWAYS</name>
+                  <description>Always (continuously sample)</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_EMUX_EM2</name>
+              <description>SS2 Trigger Select</description>
+              <bitRange>[11:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_PROCESSOR</name>
+                  <description>Processor (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_COMP0</name>
+                  <description>Analog Comparator 0</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_COMP1</name>
+                  <description>Analog Comparator 1</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_EXTERNAL</name>
+                  <description>External (GPIO PB4)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_TIMER</name>
+                  <description>Timer</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_PWM0</name>
+                  <description>PWM0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_PWM1</name>
+                  <description>PWM1</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_PWM2</name>
+                  <description>PWM2</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_PWM3</name>
+                  <description>PWM3</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM2_ALWAYS</name>
+                  <description>Always (continuously sample)</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_EMUX_EM3</name>
+              <description>SS3 Trigger Select</description>
+              <bitRange>[15:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_PROCESSOR</name>
+                  <description>Processor (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_COMP0</name>
+                  <description>Analog Comparator 0</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_COMP1</name>
+                  <description>Analog Comparator 1</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_EXTERNAL</name>
+                  <description>External (GPIO PB4)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_TIMER</name>
+                  <description>Timer</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_PWM0</name>
+                  <description>PWM0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_PWM1</name>
+                  <description>PWM1</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_PWM2</name>
+                  <description>PWM2</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_PWM3</name>
+                  <description>PWM3</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_EMUX_EM3_ALWAYS</name>
+                  <description>Always (continuously sample)</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USTAT</name>
+          <description>ADC Underflow Status</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_USTAT_UV0</name>
+              <description>SS0 FIFO Underflow</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_USTAT_UV1</name>
+              <description>SS1 FIFO Underflow</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_USTAT_UV2</name>
+              <description>SS2 FIFO Underflow</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_USTAT_UV3</name>
+              <description>SS3 FIFO Underflow</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TSSEL</name>
+          <description>ADC Trigger Source Select</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_TSSEL_PS0</name>
+              <description>PWM Unit Select</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS0_0</name>
+                  <description>PWM Unit 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS0_1</name>
+                  <description>PWM Unit 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_TSSEL_PS1</name>
+              <description>PWM Unit Select</description>
+              <bitRange>[13:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS1_0</name>
+                  <description>PWM Unit 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS1_1</name>
+                  <description>PWM Unit 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_TSSEL_PS2</name>
+              <description>PWM Unit Select</description>
+              <bitRange>[21:20]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS2_0</name>
+                  <description>PWM Unit 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS2_1</name>
+                  <description>PWM Unit 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_TSSEL_PS3</name>
+              <description>PWM Unit Select</description>
+              <bitRange>[29:28]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS3_0</name>
+                  <description>PWM Unit 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_TSSEL_PS3_1</name>
+                  <description>PWM Unit 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSPRI</name>
+          <description>ADC Sample Sequencer Priority</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSPRI_SS0</name>
+              <description>SS0 Priority</description>
+              <bitRange>[1:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSPRI_SS1</name>
+              <description>SS1 Priority</description>
+              <bitRange>[5:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSPRI_SS2</name>
+              <description>SS2 Priority</description>
+              <bitRange>[9:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSPRI_SS3</name>
+              <description>SS3 Priority</description>
+              <bitRange>[13:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SPC</name>
+          <description>ADC Sample Phase Control</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SPC_PHASE</name>
+              <description>Phase Difference</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_0</name>
+                  <description>ADC sample lags by 0.0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_22_5</name>
+                  <description>ADC sample lags by 22.5</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_45</name>
+                  <description>ADC sample lags by 45.0</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_67_5</name>
+                  <description>ADC sample lags by 67.5</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_90</name>
+                  <description>ADC sample lags by 90.0</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_112_5</name>
+                  <description>ADC sample lags by 112.5</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_135</name>
+                  <description>ADC sample lags by 135.0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_157_5</name>
+                  <description>ADC sample lags by 157.5</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_180</name>
+                  <description>ADC sample lags by 180.0</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_202_5</name>
+                  <description>ADC sample lags by 202.5</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_225</name>
+                  <description>ADC sample lags by 225.0</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_247_5</name>
+                  <description>ADC sample lags by 247.5</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_270</name>
+                  <description>ADC sample lags by 270.0</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_292_5</name>
+                  <description>ADC sample lags by 292.5</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_315</name>
+                  <description>ADC sample lags by 315.0</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SPC_PHASE_337_5</name>
+                  <description>ADC sample lags by 337.5</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSSI</name>
+          <description>ADC Processor Sample Sequence Initiate</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_PSSI_SS0</name>
+              <description>SS0 Initiate</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PSSI_SS1</name>
+              <description>SS1 Initiate</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PSSI_SS2</name>
+              <description>SS2 Initiate</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PSSI_SS3</name>
+              <description>SS3 Initiate</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PSSI_SYNCWAIT</name>
+              <description>Synchronize Wait</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PSSI_GSYNC</name>
+              <description>Global Synchronize</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAC</name>
+          <description>ADC Sample Averaging Control</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SAC_AVG</name>
+              <description>Hardware Averaging Control</description>
+              <bitRange>[2:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_SAC_AVG_OFF</name>
+                  <description>No hardware oversampling</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SAC_AVG_2X</name>
+                  <description>2x hardware oversampling</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SAC_AVG_4X</name>
+                  <description>4x hardware oversampling</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SAC_AVG_8X</name>
+                  <description>8x hardware oversampling</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SAC_AVG_16X</name>
+                  <description>16x hardware oversampling</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SAC_AVG_32X</name>
+                  <description>32x hardware oversampling</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_SAC_AVG_64X</name>
+                  <description>64x hardware oversampling</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCISC</name>
+          <description>ADC Digital Comparator Interrupt Status and Clear</description>
+          <addressOffset>0x00000034</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCISC_DCINT0</name>
+              <description>Digital Comparator 0 Interrupt Status and Clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCISC_DCINT1</name>
+              <description>Digital Comparator 1 Interrupt Status and Clear</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCISC_DCINT2</name>
+              <description>Digital Comparator 2 Interrupt Status and Clear</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCISC_DCINT3</name>
+              <description>Digital Comparator 3 Interrupt Status and Clear</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCISC_DCINT4</name>
+              <description>Digital Comparator 4 Interrupt Status and Clear</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCISC_DCINT5</name>
+              <description>Digital Comparator 5 Interrupt Status and Clear</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCISC_DCINT6</name>
+              <description>Digital Comparator 6 Interrupt Status and Clear</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCISC_DCINT7</name>
+              <description>Digital Comparator 7 Interrupt Status and Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTL</name>
+          <description>ADC Control</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_CTL_VREF</name>
+              <description>Voltage Reference Select</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_CTL_VREF_INTERNAL</name>
+                  <description>The internal reference as the voltage reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_CTL_DITHER</name>
+              <description>Dither Mode Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSMUX0</name>
+          <description>ADC Sample Sequence Input Multiplexer Select 0</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSMUX0_MUX0</name>
+              <description>1st Sample Input Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX0_MUX1</name>
+              <description>2nd Sample Input Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX0_MUX2</name>
+              <description>3rd Sample Input Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX0_MUX3</name>
+              <description>4th Sample Input Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX0_MUX4</name>
+              <description>5th Sample Input Select</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX0_MUX5</name>
+              <description>6th Sample Input Select</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX0_MUX6</name>
+              <description>7th Sample Input Select</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX0_MUX7</name>
+              <description>8th Sample Input Select</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSCTL0</name>
+          <description>ADC Sample Sequence Control 0</description>
+          <addressOffset>0x00000044</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSCTL0_D0</name>
+              <description>1st Sample Diff Input Select</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END0</name>
+              <description>1st Sample is End of Sequence</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE0</name>
+              <description>1st Sample Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS0</name>
+              <description>1st Sample Temp Sensor Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_D1</name>
+              <description>2nd Sample Diff Input Select</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END1</name>
+              <description>2nd Sample is End of Sequence</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE1</name>
+              <description>2nd Sample Interrupt Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS1</name>
+              <description>2nd Sample Temp Sensor Select</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_D2</name>
+              <description>3rd Sample Diff Input Select</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END2</name>
+              <description>3rd Sample is End of Sequence</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE2</name>
+              <description>3rd Sample Interrupt Enable</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS2</name>
+              <description>3rd Sample Temp Sensor Select</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_D3</name>
+              <description>4th Sample Diff Input Select</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END3</name>
+              <description>4th Sample is End of Sequence</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE3</name>
+              <description>4th Sample Interrupt Enable</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS3</name>
+              <description>4th Sample Temp Sensor Select</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_D4</name>
+              <description>5th Sample Diff Input Select</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END4</name>
+              <description>5th Sample is End of Sequence</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE4</name>
+              <description>5th Sample Interrupt Enable</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS4</name>
+              <description>5th Sample Temp Sensor Select</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_D5</name>
+              <description>6th Sample Diff Input Select</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END5</name>
+              <description>6th Sample is End of Sequence</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE5</name>
+              <description>6th Sample Interrupt Enable</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS5</name>
+              <description>6th Sample Temp Sensor Select</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_D6</name>
+              <description>7th Sample Diff Input Select</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END6</name>
+              <description>7th Sample is End of Sequence</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE6</name>
+              <description>7th Sample Interrupt Enable</description>
+              <bitRange>[26:26]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS6</name>
+              <description>7th Sample Temp Sensor Select</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_D7</name>
+              <description>8th Sample Diff Input Select</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_END7</name>
+              <description>8th Sample is End of Sequence</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_IE7</name>
+              <description>8th Sample Interrupt Enable</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL0_TS7</name>
+              <description>8th Sample Temp Sensor Select</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFIFO0</name>
+          <description>ADC Sample Sequence Result FIFO 0</description>
+          <addressOffset>0x00000048</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFIFO0_DATA</name>
+              <description>Conversion Result Data</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFSTAT0</name>
+          <description>ADC Sample Sequence FIFO 0 Status</description>
+          <addressOffset>0x0000004C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFSTAT0_TPTR</name>
+              <description>FIFO Tail Pointer</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT0_HPTR</name>
+              <description>FIFO Head Pointer</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT0_EMPTY</name>
+              <description>FIFO Empty</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT0_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSOP0</name>
+          <description>ADC Sample Sequence 0 Operation</description>
+          <addressOffset>0x00000050</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSOP0_S0DCOP</name>
+              <description>Sample 0 Digital Comparator Operation</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP0_S1DCOP</name>
+              <description>Sample 1 Digital Comparator Operation</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP0_S2DCOP</name>
+              <description>Sample 2 Digital Comparator Operation</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP0_S3DCOP</name>
+              <description>Sample 3 Digital Comparator Operation</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP0_S4DCOP</name>
+              <description>Sample 4 Digital Comparator Operation</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP0_S5DCOP</name>
+              <description>Sample 5 Digital Comparator Operation</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP0_S6DCOP</name>
+              <description>Sample 6 Digital Comparator Operation</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP0_S7DCOP</name>
+              <description>Sample 7 Digital Comparator Operation</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSDC0</name>
+          <description>ADC Sample Sequence 0 Digital Comparator Select</description>
+          <addressOffset>0x00000054</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSDC0_S0DCSEL</name>
+              <description>Sample 0 Digital Comparator Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC0_S1DCSEL</name>
+              <description>Sample 1 Digital Comparator Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC0_S2DCSEL</name>
+              <description>Sample 2 Digital Comparator Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC0_S3DCSEL</name>
+              <description>Sample 3 Digital Comparator Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC0_S4DCSEL</name>
+              <description>Sample 4 Digital Comparator Select</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC0_S5DCSEL</name>
+              <description>Sample 5 Digital Comparator Select</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC0_S6DCSEL</name>
+              <description>Sample 6 Digital Comparator Select</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC0_S7DCSEL</name>
+              <description>Sample 7 Digital Comparator Select</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSMUX1</name>
+          <description>ADC Sample Sequence Input Multiplexer Select 1</description>
+          <addressOffset>0x00000060</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSMUX1_MUX0</name>
+              <description>1st Sample Input Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX1_MUX1</name>
+              <description>2nd Sample Input Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX1_MUX2</name>
+              <description>3rd Sample Input Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX1_MUX3</name>
+              <description>4th Sample Input Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSCTL1</name>
+          <description>ADC Sample Sequence Control 1</description>
+          <addressOffset>0x00000064</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSCTL1_D0</name>
+              <description>1st Sample Diff Input Select</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_END0</name>
+              <description>1st Sample is End of Sequence</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_IE0</name>
+              <description>1st Sample Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_TS0</name>
+              <description>1st Sample Temp Sensor Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_D1</name>
+              <description>2nd Sample Diff Input Select</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_END1</name>
+              <description>2nd Sample is End of Sequence</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_IE1</name>
+              <description>2nd Sample Interrupt Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_TS1</name>
+              <description>2nd Sample Temp Sensor Select</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_D2</name>
+              <description>3rd Sample Diff Input Select</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_END2</name>
+              <description>3rd Sample is End of Sequence</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_IE2</name>
+              <description>3rd Sample Interrupt Enable</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_TS2</name>
+              <description>3rd Sample Temp Sensor Select</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_D3</name>
+              <description>4th Sample Diff Input Select</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_END3</name>
+              <description>4th Sample is End of Sequence</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_IE3</name>
+              <description>4th Sample Interrupt Enable</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL1_TS3</name>
+              <description>4th Sample Temp Sensor Select</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFIFO1</name>
+          <description>ADC Sample Sequence Result FIFO 1</description>
+          <addressOffset>0x00000068</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFIFO1_DATA</name>
+              <description>Conversion Result Data</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFSTAT1</name>
+          <description>ADC Sample Sequence FIFO 1 Status</description>
+          <addressOffset>0x0000006C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFSTAT1_TPTR</name>
+              <description>FIFO Tail Pointer</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT1_HPTR</name>
+              <description>FIFO Head Pointer</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT1_EMPTY</name>
+              <description>FIFO Empty</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT1_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSOP1</name>
+          <description>ADC Sample Sequence 1 Operation</description>
+          <addressOffset>0x00000070</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSOP1_S0DCOP</name>
+              <description>Sample 0 Digital Comparator Operation</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP1_S1DCOP</name>
+              <description>Sample 1 Digital Comparator Operation</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP1_S2DCOP</name>
+              <description>Sample 2 Digital Comparator Operation</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP1_S3DCOP</name>
+              <description>Sample 3 Digital Comparator Operation</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSDC1</name>
+          <description>ADC Sample Sequence 1 Digital Comparator Select</description>
+          <addressOffset>0x00000074</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSDC1_S0DCSEL</name>
+              <description>Sample 0 Digital Comparator Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC1_S1DCSEL</name>
+              <description>Sample 1 Digital Comparator Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC1_S2DCSEL</name>
+              <description>Sample 2 Digital Comparator Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC1_S3DCSEL</name>
+              <description>Sample 3 Digital Comparator Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSMUX2</name>
+          <description>ADC Sample Sequence Input Multiplexer Select 2</description>
+          <addressOffset>0x00000080</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSMUX2_MUX0</name>
+              <description>1st Sample Input Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX2_MUX1</name>
+              <description>2nd Sample Input Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX2_MUX2</name>
+              <description>3rd Sample Input Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSMUX2_MUX3</name>
+              <description>4th Sample Input Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSCTL2</name>
+          <description>ADC Sample Sequence Control 2</description>
+          <addressOffset>0x00000084</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSCTL2_D0</name>
+              <description>1st Sample Diff Input Select</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_END0</name>
+              <description>1st Sample is End of Sequence</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_IE0</name>
+              <description>1st Sample Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_TS0</name>
+              <description>1st Sample Temp Sensor Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_D1</name>
+              <description>2nd Sample Diff Input Select</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_END1</name>
+              <description>2nd Sample is End of Sequence</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_IE1</name>
+              <description>2nd Sample Interrupt Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_TS1</name>
+              <description>2nd Sample Temp Sensor Select</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_D2</name>
+              <description>3rd Sample Diff Input Select</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_END2</name>
+              <description>3rd Sample is End of Sequence</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_IE2</name>
+              <description>3rd Sample Interrupt Enable</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_TS2</name>
+              <description>3rd Sample Temp Sensor Select</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_D3</name>
+              <description>4th Sample Diff Input Select</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_END3</name>
+              <description>4th Sample is End of Sequence</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_IE3</name>
+              <description>4th Sample Interrupt Enable</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL2_TS3</name>
+              <description>4th Sample Temp Sensor Select</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFIFO2</name>
+          <description>ADC Sample Sequence Result FIFO 2</description>
+          <addressOffset>0x00000088</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFIFO2_DATA</name>
+              <description>Conversion Result Data</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFSTAT2</name>
+          <description>ADC Sample Sequence FIFO 2 Status</description>
+          <addressOffset>0x0000008C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFSTAT2_TPTR</name>
+              <description>FIFO Tail Pointer</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT2_HPTR</name>
+              <description>FIFO Head Pointer</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT2_EMPTY</name>
+              <description>FIFO Empty</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT2_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSOP2</name>
+          <description>ADC Sample Sequence 2 Operation</description>
+          <addressOffset>0x00000090</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSOP2_S0DCOP</name>
+              <description>Sample 0 Digital Comparator Operation</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP2_S1DCOP</name>
+              <description>Sample 1 Digital Comparator Operation</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP2_S2DCOP</name>
+              <description>Sample 2 Digital Comparator Operation</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSOP2_S3DCOP</name>
+              <description>Sample 3 Digital Comparator Operation</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSDC2</name>
+          <description>ADC Sample Sequence 2 Digital Comparator Select</description>
+          <addressOffset>0x00000094</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSDC2_S0DCSEL</name>
+              <description>Sample 0 Digital Comparator Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC2_S1DCSEL</name>
+              <description>Sample 1 Digital Comparator Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC2_S2DCSEL</name>
+              <description>Sample 2 Digital Comparator Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSDC2_S3DCSEL</name>
+              <description>Sample 3 Digital Comparator Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSMUX3</name>
+          <description>ADC Sample Sequence Input Multiplexer Select 3</description>
+          <addressOffset>0x000000A0</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSMUX3_MUX0</name>
+              <description>1st Sample Input Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSCTL3</name>
+          <description>ADC Sample Sequence Control 3</description>
+          <addressOffset>0x000000A4</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSCTL3_D0</name>
+              <description>1st Sample Diff Input Select</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL3_END0</name>
+              <description>1st Sample is End of Sequence</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL3_IE0</name>
+              <description>1st Sample Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSCTL3_TS0</name>
+              <description>1st Sample Temp Sensor Select</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFIFO3</name>
+          <description>ADC Sample Sequence Result FIFO 3</description>
+          <addressOffset>0x000000A8</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFIFO3_DATA</name>
+              <description>Conversion Result Data</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSFSTAT3</name>
+          <description>ADC Sample Sequence FIFO 3 Status</description>
+          <addressOffset>0x000000AC</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSFSTAT3_TPTR</name>
+              <description>FIFO Tail Pointer</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT3_HPTR</name>
+              <description>FIFO Head Pointer</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT3_EMPTY</name>
+              <description>FIFO Empty</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>ADC_SSFSTAT3_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSOP3</name>
+          <description>ADC Sample Sequence 3 Operation</description>
+          <addressOffset>0x000000B0</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSOP3_S0DCOP</name>
+              <description>Sample 0 Digital Comparator Operation</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSDC3</name>
+          <description>ADC Sample Sequence 3 Digital Comparator Select</description>
+          <addressOffset>0x000000B4</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_SSDC3_S0DCSEL</name>
+              <description>Sample 0 Digital Comparator Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCRIC</name>
+          <description>ADC Digital Comparator Reset Initial Conditions</description>
+          <addressOffset>0x00000D00</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>ADC_DCRIC_DCINT0</name>
+              <description>Digital Comparator Interrupt 0</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCINT1</name>
+              <description>Digital Comparator Interrupt 1</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCINT2</name>
+              <description>Digital Comparator Interrupt 2</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCINT3</name>
+              <description>Digital Comparator Interrupt 3</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCINT4</name>
+              <description>Digital Comparator Interrupt 4</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCINT5</name>
+              <description>Digital Comparator Interrupt 5</description>
+              <bitRange>[5:5]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCINT6</name>
+              <description>Digital Comparator Interrupt 6</description>
+              <bitRange>[6:6]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCINT7</name>
+              <description>Digital Comparator Interrupt 7</description>
+              <bitRange>[7:7]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG0</name>
+              <description>Digital Comparator Trigger 0</description>
+              <bitRange>[16:16]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG1</name>
+              <description>Digital Comparator Trigger 1</description>
+              <bitRange>[17:17]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG2</name>
+              <description>Digital Comparator Trigger 2</description>
+              <bitRange>[18:18]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG3</name>
+              <description>Digital Comparator Trigger 3</description>
+              <bitRange>[19:19]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG4</name>
+              <description>Digital Comparator Trigger 4</description>
+              <bitRange>[20:20]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG5</name>
+              <description>Digital Comparator Trigger 5</description>
+              <bitRange>[21:21]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG6</name>
+              <description>Digital Comparator Trigger 6</description>
+              <bitRange>[22:22]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ADC_DCRIC_DCTRIG7</name>
+              <description>Digital Comparator Trigger 7</description>
+              <bitRange>[23:23]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL0</name>
+          <description>ADC Digital Comparator Control 0</description>
+          <addressOffset>0x00000E00</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL0_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL0_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL0_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL0_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL0_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL0_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL0_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL1</name>
+          <description>ADC Digital Comparator Control 1</description>
+          <addressOffset>0x00000E04</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL1_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL1_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL1_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL1_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL1_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL1_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL1_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL2</name>
+          <description>ADC Digital Comparator Control 2</description>
+          <addressOffset>0x00000E08</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL2_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL2_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL2_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL2_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL2_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL2_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL2_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL3</name>
+          <description>ADC Digital Comparator Control 3</description>
+          <addressOffset>0x00000E0C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL3_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL3_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL3_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL3_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL3_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL3_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL3_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL4</name>
+          <description>ADC Digital Comparator Control 4</description>
+          <addressOffset>0x00000E10</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL4_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL4_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL4_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL4_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL4_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL4_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL4_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL5</name>
+          <description>ADC Digital Comparator Control 5</description>
+          <addressOffset>0x00000E14</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL5_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL5_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL5_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL5_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL5_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL5_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL5_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL6</name>
+          <description>ADC Digital Comparator Control 6</description>
+          <addressOffset>0x00000E18</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL6_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL6_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL6_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL6_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL6_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL6_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL6_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCTL7</name>
+          <description>ADC Digital Comparator Control 7</description>
+          <addressOffset>0x00000E1C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCTL7_CIM</name>
+              <description>Comparison Interrupt Mode</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CIM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CIM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CIM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CIM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL7_CIC</name>
+              <description>Comparison Interrupt Condition</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CIC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CIC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CIC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL7_CIE</name>
+              <description>Comparison Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCTL7_CTM</name>
+              <description>Comparison Trigger Mode</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CTM_ALWAYS</name>
+                  <description>Always</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CTM_ONCE</name>
+                  <description>Once</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CTM_HALWAYS</name>
+                  <description>Hysteresis Always</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CTM_HONCE</name>
+                  <description>Hysteresis Once</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL7_CTC</name>
+              <description>Comparison Trigger Condition</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CTC_LOW</name>
+                  <description>Low Band</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CTC_MID</name>
+                  <description>Mid Band</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_DCCTL7_CTC_HIGH</name>
+                  <description>High Band</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_DCCTL7_CTE</name>
+              <description>Comparison Trigger Enable</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP0</name>
+          <description>ADC Digital Comparator Range 0</description>
+          <addressOffset>0x00000E40</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP0_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP0_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP1</name>
+          <description>ADC Digital Comparator Range 1</description>
+          <addressOffset>0x00000E44</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP1_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP1_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP2</name>
+          <description>ADC Digital Comparator Range 2</description>
+          <addressOffset>0x00000E48</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP2_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP2_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP3</name>
+          <description>ADC Digital Comparator Range 3</description>
+          <addressOffset>0x00000E4C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP3_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP3_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP4</name>
+          <description>ADC Digital Comparator Range 4</description>
+          <addressOffset>0x00000E50</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP4_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP4_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP5</name>
+          <description>ADC Digital Comparator Range 5</description>
+          <addressOffset>0x00000E54</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP5_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP5_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP6</name>
+          <description>ADC Digital Comparator Range 6</description>
+          <addressOffset>0x00000E58</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP6_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP6_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCCMP7</name>
+          <description>ADC Digital Comparator Range 7</description>
+          <addressOffset>0x00000E5C</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_DCCMP7_COMP0</name>
+              <description>Compare 0</description>
+              <bitRange>[11:0]</bitRange>
+            </field>
+            <field>
+              <name>ADC_DCCMP7_COMP1</name>
+              <description>Compare 1</description>
+              <bitRange>[27:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>ADC Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_PP_MSR</name>
+              <description>Maximum ADC Sample Rate</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_PP_MSR_125K</name>
+                  <description>125 ksps</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_PP_MSR_250K</name>
+                  <description>250 ksps</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_PP_MSR_500K</name>
+                  <description>500 ksps</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_PP_MSR_1M</name>
+                  <description>1 Msps</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_PP_CH</name>
+              <description>ADC Channel Count</description>
+              <bitRange>[9:4]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PP_DC</name>
+              <description>Digital Comparator Count</description>
+              <bitRange>[15:10]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PP_TYPE</name>
+              <description>ADC Architecture</description>
+              <bitRange>[17:16]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_PP_TYPE_SAR</name>
+                  <description>SAR</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADC_PP_RSL</name>
+              <description>Resolution</description>
+              <bitRange>[22:18]</bitRange>
+            </field>
+            <field>
+              <name>ADC_PP_TS</name>
+              <description>Temperature Sensor</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PC</name>
+          <description>ADC Peripheral Configuration</description>
+          <addressOffset>0x00000FC4</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_PC_SR</name>
+              <description>ADC Sample Rate</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_PC_SR_125K</name>
+                  <description>125 ksps</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_PC_SR_250K</name>
+                  <description>250 ksps</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_PC_SR_500K</name>
+                  <description>500 ksps</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_PC_SR_1M</name>
+                  <description>1 Msps</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CC</name>
+          <description>ADC Clock Configuration</description>
+          <addressOffset>0x00000FC8</addressOffset>
+          <fields>
+            <field>
+              <name>ADC_CC_CS</name>
+              <description>ADC Clock Source</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>ADC_CC_CS_SYSPLL</name>
+                  <description>Either the system clock (if the PLL bypass is in effect) or the 16 MHz clock derived from PLL / 25 (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC_CC_CS_PIOSC</name>
+                  <description>PIOSC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="ADC0">
+      <name>ADC1</name>
+      <prependToName>ADC1</prependToName>
+      <baseAddress>0x40039000</baseAddress>
+      <interrupt><name>ADC1SS0</name><value>48</value></interrupt>
+      <interrupt><name>ADC1SS1</name><value>49</value></interrupt>
+      <interrupt><name>ADC1SS2</name><value>50</value></interrupt>
+      <interrupt><name>ADC1SS3</name><value>51</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>COMP</name>
+      <description>Register map for COMP peripheral</description>
+      <groupName>COMP</groupName>
+      <prependToName>COMP</prependToName>
+      <baseAddress>0x4003C000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>COMP0</name><value>25</value></interrupt>
+      <interrupt><name>COMP1</name><value>26</value></interrupt>
+      <registers>
+        <register>
+          <name>ACMIS</name>
+          <description>Analog Comparator Masked Interrupt Status</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACMIS_IN0</name>
+              <description>Comparator 0 Masked Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACMIS_IN1</name>
+              <description>Comparator 1 Masked Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACRIS</name>
+          <description>Analog Comparator Raw Interrupt Status</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACRIS_IN0</name>
+              <description>Comparator 0 Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACRIS_IN1</name>
+              <description>Comparator 1 Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACINTEN</name>
+          <description>Analog Comparator Interrupt Enable</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACINTEN_IN0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACINTEN_IN1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACREFCTL</name>
+          <description>Analog Comparator Reference Voltage Control</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACREFCTL_VREF</name>
+              <description>Resistor Ladder Voltage Ref</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACREFCTL_RNG</name>
+              <description>Resistor Ladder Range</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACREFCTL_EN</name>
+              <description>Resistor Ladder Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACSTAT0</name>
+          <description>Analog Comparator Status 0</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACSTAT0_OVAL</name>
+              <description>Comparator Output Value</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACCTL0</name>
+          <description>Analog Comparator Control 0</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACCTL0_CINV</name>
+              <description>Comparator Output Invert</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACCTL0_ISEN</name>
+              <description>Interrupt Sense</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_ISEN_LEVEL</name>
+                  <description>Level sense, see ISLVAL</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_ISEN_FALL</name>
+                  <description>Falling edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_ISEN_RISE</name>
+                  <description>Rising edge</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_ISEN_BOTH</name>
+                  <description>Either edge</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>COMP_ACCTL0_ISLVAL</name>
+              <description>Interrupt Sense Level Value</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACCTL0_TSEN</name>
+              <description>Trigger Sense</description>
+              <bitRange>[6:5]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_TSEN_LEVEL</name>
+                  <description>Level sense, see TSLVAL</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_TSEN_FALL</name>
+                  <description>Falling edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_TSEN_RISE</name>
+                  <description>Rising edge</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_TSEN_BOTH</name>
+                  <description>Either edge</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>COMP_ACCTL0_TSLVAL</name>
+              <description>Trigger Sense Level Value</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACCTL0_ASRCP</name>
+              <description>Analog Source Positive</description>
+              <bitRange>[10:9]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_ASRCP_PIN</name>
+                  <description>Pin value of Cn+</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_ASRCP_PIN0</name>
+                  <description>Pin value of C0+</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL0_ASRCP_REF</name>
+                  <description>Internal voltage reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>COMP_ACCTL0_TOEN</name>
+              <description>Trigger Output Enable</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACSTAT1</name>
+          <description>Analog Comparator Status 1</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACSTAT1_OVAL</name>
+              <description>Comparator Output Value</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACCTL1</name>
+          <description>Analog Comparator Control 1</description>
+          <addressOffset>0x00000044</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_ACCTL1_CINV</name>
+              <description>Comparator Output Invert</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACCTL1_ISEN</name>
+              <description>Interrupt Sense</description>
+              <bitRange>[3:2]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_ISEN_LEVEL</name>
+                  <description>Level sense, see ISLVAL</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_ISEN_FALL</name>
+                  <description>Falling edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_ISEN_RISE</name>
+                  <description>Rising edge</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_ISEN_BOTH</name>
+                  <description>Either edge</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>COMP_ACCTL1_ISLVAL</name>
+              <description>Interrupt Sense Level Value</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACCTL1_TSEN</name>
+              <description>Trigger Sense</description>
+              <bitRange>[6:5]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_TSEN_LEVEL</name>
+                  <description>Level sense, see TSLVAL</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_TSEN_FALL</name>
+                  <description>Falling edge</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_TSEN_RISE</name>
+                  <description>Rising edge</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_TSEN_BOTH</name>
+                  <description>Either edge</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>COMP_ACCTL1_TSLVAL</name>
+              <description>Trigger Sense Level Value</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>COMP_ACCTL1_ASRCP</name>
+              <description>Analog Source Positive</description>
+              <bitRange>[10:9]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_ASRCP_PIN</name>
+                  <description>Pin value of Cn+</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_ASRCP_PIN0</name>
+                  <description>Pin value of C0+</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COMP_ACCTL1_ASRCP_REF</name>
+                  <description>Internal voltage reference (VIREF)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>COMP_ACCTL1_TOEN</name>
+              <description>Trigger Output Enable</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>Analog Comparator Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>COMP_PP_CMP0</name>
+              <description>Comparator 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>COMP_PP_CMP1</name>
+              <description>Comparator 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>COMP_PP_C0O</name>
+              <description>Comparator Output 0 Present</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>COMP_PP_C1O</name>
+              <description>Comparator Output 1 Present</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>CAN0</name>
+      <description>Register map for CAN0 peripheral</description>
+      <groupName>CAN</groupName>
+      <prependToName>CAN0</prependToName>
+      <baseAddress>0x40040000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>CAN0</name><value>39</value></interrupt>
+      <registers>
+        <register>
+          <name>CTL</name>
+          <description>CAN Control</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_CTL_INIT</name>
+              <description>Initialization</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_CTL_IE</name>
+              <description>CAN Interrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CAN_CTL_SIE</name>
+              <description>Status Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CAN_CTL_EIE</name>
+              <description>Error Interrupt Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CAN_CTL_DAR</name>
+              <description>Disable Automatic-Retransmission</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>CAN_CTL_CCE</name>
+              <description>Configuration Change Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>CAN_CTL_TEST</name>
+              <description>Test Mode Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STS</name>
+          <description>CAN Status</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_STS_LEC</name>
+              <description>Last Error Code</description>
+              <bitRange>[2:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_NONE</name>
+                  <description>No Error</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_STUFF</name>
+                  <description>Stuff Error</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_FORM</name>
+                  <description>Format Error</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_ACK</name>
+                  <description>ACK Error</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_BIT1</name>
+                  <description>Bit 1 Error</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_BIT0</name>
+                  <description>Bit 0 Error</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_CRC</name>
+                  <description>CRC Error</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_STS_LEC_NOEVENT</name>
+                  <description>No Event</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAN_STS_TXOK</name>
+              <description>Transmitted a Message Successfully</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CAN_STS_RXOK</name>
+              <description>Received a Message Successfully</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CAN_STS_EPASS</name>
+              <description>Error Passive</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>CAN_STS_EWARN</name>
+              <description>Warning Status</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>CAN_STS_BOFF</name>
+              <description>Bus-Off Status</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ERR</name>
+          <description>CAN Error Counter</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_ERR_TEC</name>
+              <description>Transmit Error Counter</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_ERR_REC</name>
+              <description>Receive Error Counter</description>
+              <bitRange>[14:8]</bitRange>
+            </field>
+            <field>
+              <name>CAN_ERR_RP</name>
+              <description>Received Error Passive</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BIT</name>
+          <description>CAN Bit Timing</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_BIT_BRP</name>
+              <description>Baud Rate Prescaler</description>
+              <bitRange>[5:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_BIT_SJW</name>
+              <description>(Re)Synchronization Jump Width</description>
+              <bitRange>[7:6]</bitRange>
+            </field>
+            <field>
+              <name>CAN_BIT_TSEG1</name>
+              <description>Time Segment Before Sample Point</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>CAN_BIT_TSEG2</name>
+              <description>Time Segment after Sample Point</description>
+              <bitRange>[14:12]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INT</name>
+          <description>CAN Interrupt</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_INT_INTID</name>
+              <description>Interrupt Identifier</description>
+              <bitRange>[15:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CAN_INT_INTID_NONE</name>
+                  <description>No interrupt pending</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_INT_INTID_STATUS</name>
+                  <description>Status Interrupt</description>
+                  <value>0x8000</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TST</name>
+          <description>CAN Test</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_TST_BASIC</name>
+              <description>Basic Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CAN_TST_SILENT</name>
+              <description>Silent Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CAN_TST_LBACK</name>
+              <description>Loopback Mode</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CAN_TST_TX</name>
+              <description>Transmit Control</description>
+              <bitRange>[6:5]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>CAN_TST_TX_CANCTL</name>
+                  <description>CAN Module Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_TST_TX_SAMPLE</name>
+                  <description>Sample Point</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_TST_TX_DOMINANT</name>
+                  <description>Driven Low</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAN_TST_TX_RECESSIVE</name>
+                  <description>Driven High</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAN_TST_RX</name>
+              <description>Receive Observation</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRPE</name>
+          <description>CAN Baud Rate Prescaler Extension</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_BRPE_BRPE</name>
+              <description>Baud Rate Prescaler Extension</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1CRQ</name>
+          <description>CAN IF1 Command Request</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1CRQ_MNUM</name>
+              <description>Message Number</description>
+              <bitRange>[5:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CRQ_BUSY</name>
+              <description>Busy Flag</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1CMSK</name>
+          <description>CAN IF1 Command Mask</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1CMSK_DATAB</name>
+              <description>Access Data Byte 4 to 7</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CMSK_DATAA</name>
+              <description>Access Data Byte 0 to 3</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CMSK_NEWDAT</name>
+              <description>Access New Data</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CMSK_CLRINTPND</name>
+              <description>Clear Interrupt Pending Bit</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CMSK_CONTROL</name>
+              <description>Access Control Bits</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CMSK_ARB</name>
+              <description>Access Arbitration Bits</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CMSK_MASK</name>
+              <description>Access Mask Bits</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1CMSK_WRNRD</name>
+              <description>Write, Not Read</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1CMSK</name>
+          <description>CAN IF1 Command Mask</description>
+          <alternateGroup>CAN0_ALT</alternateGroup>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1CMSK_TXRQST</name>
+              <description>Access Transmission Request</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1MSK1</name>
+          <description>CAN IF1 Mask 1</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1MSK1_IDMSK</name>
+              <description>Identifier Mask</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1MSK2</name>
+          <description>CAN IF1 Mask 2</description>
+          <addressOffset>0x0000002C</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1MSK2_IDMSK</name>
+              <description>Identifier Mask</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MSK2_MDIR</name>
+              <description>Mask Message Direction</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MSK2_MXTD</name>
+              <description>Mask Extended Identifier</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1ARB1</name>
+          <description>CAN IF1 Arbitration 1</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1ARB1_ID</name>
+              <description>Message Identifier</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1ARB2</name>
+          <description>CAN IF1 Arbitration 2</description>
+          <addressOffset>0x00000034</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1ARB2_ID</name>
+              <description>Message Identifier</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1ARB2_DIR</name>
+              <description>Message Direction</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1ARB2_XTD</name>
+              <description>Extended Identifier</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1ARB2_MSGVAL</name>
+              <description>Message Valid</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1MCTL</name>
+          <description>CAN IF1 Message Control</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1MCTL_DLC</name>
+              <description>Data Length Code</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_EOB</name>
+              <description>End of Buffer</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_TXRQST</name>
+              <description>Transmit Request</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_RMTEN</name>
+              <description>Remote Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_RXIE</name>
+              <description>Receive Interrupt Enable</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_TXIE</name>
+              <description>Transmit Interrupt Enable</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_UMASK</name>
+              <description>Use Acceptance Mask</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_INTPND</name>
+              <description>Interrupt Pending</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_MSGLST</name>
+              <description>Message Lost</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF1MCTL_NEWDAT</name>
+              <description>New Data</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1DA1</name>
+          <description>CAN IF1 Data A1</description>
+          <addressOffset>0x0000003C</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1DA1_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1DA2</name>
+          <description>CAN IF1 Data A2</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1DA2_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1DB1</name>
+          <description>CAN IF1 Data B1</description>
+          <addressOffset>0x00000044</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1DB1_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF1DB2</name>
+          <description>CAN IF1 Data B2</description>
+          <addressOffset>0x00000048</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF1DB2_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2CRQ</name>
+          <description>CAN IF2 Command Request</description>
+          <addressOffset>0x00000080</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2CRQ_MNUM</name>
+              <description>Message Number</description>
+              <bitRange>[5:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CRQ_BUSY</name>
+              <description>Busy Flag</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2CMSK</name>
+          <description>CAN IF2 Command Mask</description>
+          <addressOffset>0x00000084</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2CMSK_DATAB</name>
+              <description>Access Data Byte 4 to 7</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CMSK_DATAA</name>
+              <description>Access Data Byte 0 to 3</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CMSK_NEWDAT</name>
+              <description>Access New Data</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CMSK_CLRINTPND</name>
+              <description>Clear Interrupt Pending Bit</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CMSK_CONTROL</name>
+              <description>Access Control Bits</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CMSK_ARB</name>
+              <description>Access Arbitration Bits</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CMSK_MASK</name>
+              <description>Access Mask Bits</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2CMSK_WRNRD</name>
+              <description>Write, Not Read</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2CMSK</name>
+          <description>CAN IF2 Command Mask</description>
+          <alternateGroup>CAN0_ALT</alternateGroup>
+          <addressOffset>0x00000084</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2CMSK_TXRQST</name>
+              <description>Access Transmission Request</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2MSK1</name>
+          <description>CAN IF2 Mask 1</description>
+          <addressOffset>0x00000088</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2MSK1_IDMSK</name>
+              <description>Identifier Mask</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2MSK2</name>
+          <description>CAN IF2 Mask 2</description>
+          <addressOffset>0x0000008C</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2MSK2_IDMSK</name>
+              <description>Identifier Mask</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MSK2_MDIR</name>
+              <description>Mask Message Direction</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MSK2_MXTD</name>
+              <description>Mask Extended Identifier</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2ARB1</name>
+          <description>CAN IF2 Arbitration 1</description>
+          <addressOffset>0x00000090</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2ARB1_ID</name>
+              <description>Message Identifier</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2ARB2</name>
+          <description>CAN IF2 Arbitration 2</description>
+          <addressOffset>0x00000094</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2ARB2_ID</name>
+              <description>Message Identifier</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2ARB2_DIR</name>
+              <description>Message Direction</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2ARB2_XTD</name>
+              <description>Extended Identifier</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2ARB2_MSGVAL</name>
+              <description>Message Valid</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2MCTL</name>
+          <description>CAN IF2 Message Control</description>
+          <addressOffset>0x00000098</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2MCTL_DLC</name>
+              <description>Data Length Code</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_EOB</name>
+              <description>End of Buffer</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_TXRQST</name>
+              <description>Transmit Request</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_RMTEN</name>
+              <description>Remote Enable</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_RXIE</name>
+              <description>Receive Interrupt Enable</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_TXIE</name>
+              <description>Transmit Interrupt Enable</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_UMASK</name>
+              <description>Use Acceptance Mask</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_INTPND</name>
+              <description>Interrupt Pending</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_MSGLST</name>
+              <description>Message Lost</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>CAN_IF2MCTL_NEWDAT</name>
+              <description>New Data</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2DA1</name>
+          <description>CAN IF2 Data A1</description>
+          <addressOffset>0x0000009C</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2DA1_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2DA2</name>
+          <description>CAN IF2 Data A2</description>
+          <addressOffset>0x000000A0</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2DA2_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2DB1</name>
+          <description>CAN IF2 Data B1</description>
+          <addressOffset>0x000000A4</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2DB1_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IF2DB2</name>
+          <description>CAN IF2 Data B2</description>
+          <addressOffset>0x000000A8</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_IF2DB2_DATA</name>
+              <description>Data</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXRQ1</name>
+          <description>CAN Transmission Request 1</description>
+          <addressOffset>0x00000100</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_TXRQ1_TXRQST</name>
+              <description>Transmission Request Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXRQ2</name>
+          <description>CAN Transmission Request 2</description>
+          <addressOffset>0x00000104</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_TXRQ2_TXRQST</name>
+              <description>Transmission Request Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NWDA1</name>
+          <description>CAN New Data 1</description>
+          <addressOffset>0x00000120</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_NWDA1_NEWDAT</name>
+              <description>New Data Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NWDA2</name>
+          <description>CAN New Data 2</description>
+          <addressOffset>0x00000124</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_NWDA2_NEWDAT</name>
+              <description>New Data Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MSG1INT</name>
+          <description>CAN Message 1 Interrupt Pending</description>
+          <addressOffset>0x00000140</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_MSG1INT_INTPND</name>
+              <description>Interrupt Pending Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MSG2INT</name>
+          <description>CAN Message 2 Interrupt Pending</description>
+          <addressOffset>0x00000144</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_MSG2INT_INTPND</name>
+              <description>Interrupt Pending Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MSG1VAL</name>
+          <description>CAN Message 1 Valid</description>
+          <addressOffset>0x00000160</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_MSG1VAL_MSGVAL</name>
+              <description>Message Valid Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MSG2VAL</name>
+          <description>CAN Message 2 Valid</description>
+          <addressOffset>0x00000164</addressOffset>
+          <fields>
+            <field>
+              <name>CAN_MSG2VAL_MSGVAL</name>
+              <description>Message Valid Bits</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="CAN0">
+      <name>CAN1</name>
+      <prependToName>CAN1</prependToName>
+      <baseAddress>0x40041000</baseAddress>
+      <interrupt><name>CAN1</name><value>40</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>WTIMER2</name>
+      <prependToName>WTIMER2</prependToName>
+      <baseAddress>0x4004C000</baseAddress>
+      <interrupt><name>WTIMER2A</name><value>98</value></interrupt>
+      <interrupt><name>WTIMER2B</name><value>99</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>WTIMER3</name>
+      <prependToName>WTIMER3</prependToName>
+      <baseAddress>0x4004D000</baseAddress>
+      <interrupt><name>WTIMER3A</name><value>100</value></interrupt>
+      <interrupt><name>WTIMER3B</name><value>101</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>WTIMER4</name>
+      <prependToName>WTIMER4</prependToName>
+      <baseAddress>0x4004E000</baseAddress>
+      <interrupt><name>WTIMER4A</name><value>102</value></interrupt>
+      <interrupt><name>WTIMER4B</name><value>103</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="TIMER0">
+      <name>WTIMER5</name>
+      <prependToName>WTIMER5</prependToName>
+      <baseAddress>0x4004F000</baseAddress>
+      <interrupt><name>WTIMER5A</name><value>104</value></interrupt>
+      <interrupt><name>WTIMER5B</name><value>105</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>USB0</name>
+      <description>Register map for USB0 peripheral</description>
+      <groupName>USB</groupName>
+      <prependToName>USB0</prependToName>
+      <baseAddress>0x40050000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>USB0</name><value>44</value></interrupt>
+      <registers>
+        <register>
+          <name>FADDR</name>
+          <description>USB Device Functional Address</description>
+          <addressOffset>0x00000000</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_FADDR</name>
+              <description>Function Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>POWER</name>
+          <description>USB Power</description>
+          <addressOffset>0x00000001</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_POWER_PWRDNPHY</name>
+              <description>Power Down PHY</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_POWER_SUSPEND</name>
+              <description>SUSPEND Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_POWER_RESUME</name>
+              <description>RESUME Signaling</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_POWER_RESET</name>
+              <description>RESET Signaling</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_POWER_SOFTCONN</name>
+              <description>Soft Connect/Disconnect</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_POWER_ISOUP</name>
+              <description>Isochronous Update</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXIS</name>
+          <description>USB Transmit Interrupt Status</description>
+          <addressOffset>0x00000002</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXIS_EP0</name>
+              <description>TX and RX Endpoint 0 Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIS_EP1</name>
+              <description>TX Endpoint 1 Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIS_EP2</name>
+              <description>TX Endpoint 2 Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIS_EP3</name>
+              <description>TX Endpoint 3 Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIS_EP4</name>
+              <description>TX Endpoint 4 Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIS_EP5</name>
+              <description>TX Endpoint 5 Interrupt</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIS_EP6</name>
+              <description>TX Endpoint 6 Interrupt</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIS_EP7</name>
+              <description>TX Endpoint 7 Interrupt</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXIS</name>
+          <description>USB Receive Interrupt Status</description>
+          <addressOffset>0x00000004</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXIS_EP1</name>
+              <description>RX Endpoint 1 Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIS_EP2</name>
+              <description>RX Endpoint 2 Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIS_EP3</name>
+              <description>RX Endpoint 3 Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIS_EP4</name>
+              <description>RX Endpoint 4 Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIS_EP5</name>
+              <description>RX Endpoint 5 Interrupt</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIS_EP6</name>
+              <description>RX Endpoint 6 Interrupt</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIS_EP7</name>
+              <description>RX Endpoint 7 Interrupt</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXIE</name>
+          <description>USB Transmit Interrupt Enable</description>
+          <addressOffset>0x00000006</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXIE_EP0</name>
+              <description>TX and RX Endpoint 0 Interrupt Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIE_EP1</name>
+              <description>TX Endpoint 1 Interrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIE_EP2</name>
+              <description>TX Endpoint 2 Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIE_EP3</name>
+              <description>TX Endpoint 3 Interrupt Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIE_EP4</name>
+              <description>TX Endpoint 4 Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIE_EP5</name>
+              <description>TX Endpoint 5 Interrupt Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIE_EP6</name>
+              <description>TX Endpoint 6 Interrupt Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXIE_EP7</name>
+              <description>TX Endpoint 7 Interrupt Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXIE</name>
+          <description>USB Receive Interrupt Enable</description>
+          <addressOffset>0x00000008</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXIE_EP1</name>
+              <description>RX Endpoint 1 Interrupt Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIE_EP2</name>
+              <description>RX Endpoint 2 Interrupt Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIE_EP3</name>
+              <description>RX Endpoint 3 Interrupt Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIE_EP4</name>
+              <description>RX Endpoint 4 Interrupt Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIE_EP5</name>
+              <description>RX Endpoint 5 Interrupt Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIE_EP6</name>
+              <description>RX Endpoint 6 Interrupt Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXIE_EP7</name>
+              <description>RX Endpoint 7 Interrupt Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IS</name>
+          <description>USB General Interrupt Status</description>
+          <addressOffset>0x0000000A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_IS_SUSPEND</name>
+              <description>SUSPEND Signaling Detected</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_IS_RESUME</name>
+              <description>RESUME Signaling Detected</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_IS_BABBLE</name>
+              <description>Babble Detected</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_IS_SOF</name>
+              <description>Start of Frame</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_IS_CONN</name>
+              <description>Session Connect</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_IS_DISCON</name>
+              <description>Session Disconnect</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_IS_SESREQ</name>
+              <description>SESSION REQUEST</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_IS_VBUSERR</name>
+              <description>VBUS Error</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IS</name>
+          <description>USB General Interrupt Status</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000000A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_IS_RESET</name>
+              <description>RESET Signaling Detected</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IE</name>
+          <description>USB Interrupt Enable</description>
+          <addressOffset>0x0000000B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_IE_SUSPND</name>
+              <description>Enable SUSPEND Interrupt</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_IE_RESUME</name>
+              <description>Enable RESUME Interrupt</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_IE_BABBLE</name>
+              <description>Enable Babble Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_IE_SOF</name>
+              <description>Enable Start-of-Frame Interrupt</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_IE_CONN</name>
+              <description>Enable Connect Interrupt</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_IE_DISCON</name>
+              <description>Enable Disconnect Interrupt</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_IE_SESREQ</name>
+              <description>Enable Session Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_IE_VBUSERR</name>
+              <description>Enable VBUS Error Interrupt</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IE</name>
+          <description>USB Interrupt Enable</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000000B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_IE_RESET</name>
+              <description>Enable RESET Interrupt</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FRAME</name>
+          <description>USB Frame Value</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_FRAME</name>
+              <description>Frame Number</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPIDX</name>
+          <description>USB Endpoint Index</description>
+          <addressOffset>0x0000000E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_EPIDX_EPIDX</name>
+              <description>Endpoint Index</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TEST</name>
+          <description>USB Test Mode</description>
+          <addressOffset>0x0000000F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TEST_FORCEFS</name>
+              <description>Force Full-Speed Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TEST_FIFOACC</name>
+              <description>FIFO Access</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TEST_FORCEH</name>
+              <description>Force Host Mode</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO0</name>
+          <description>USB FIFO Endpoint 0</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO0_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO1</name>
+          <description>USB FIFO Endpoint 1</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO1_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO2</name>
+          <description>USB FIFO Endpoint 2</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO2_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO3</name>
+          <description>USB FIFO Endpoint 3</description>
+          <addressOffset>0x0000002C</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO3_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO4</name>
+          <description>USB FIFO Endpoint 4</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO4_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO5</name>
+          <description>USB FIFO Endpoint 5</description>
+          <addressOffset>0x00000034</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO5_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO6</name>
+          <description>USB FIFO Endpoint 6</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO6_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FIFO7</name>
+          <description>USB FIFO Endpoint 7</description>
+          <addressOffset>0x0000003C</addressOffset>
+          <fields>
+            <field>
+              <name>USB_FIFO7_EPDATA</name>
+              <description>Endpoint Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DEVCTL</name>
+          <description>USB Device Control</description>
+          <addressOffset>0x00000060</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_DEVCTL_SESSION</name>
+              <description>Session Start/End</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_DEVCTL_HOSTREQ</name>
+              <description>Host Request</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_DEVCTL_HOST</name>
+              <description>Host Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_DEVCTL_VBUS</name>
+              <description>VBUS Level</description>
+              <bitRange>[4:3]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_DEVCTL_VBUS_NONE</name>
+                  <description>Below SessionEnd</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_DEVCTL_VBUS_SEND</name>
+                  <description>Above SessionEnd, below AValid</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_DEVCTL_VBUS_AVALID</name>
+                  <description>Above AValid, below VBUSValid</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_DEVCTL_VBUS_VALID</name>
+                  <description>Above VBUSValid</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_DEVCTL_LSDEV</name>
+              <description>Low-Speed Device Detected</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_DEVCTL_FSDEV</name>
+              <description>Full-Speed Device Detected</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_DEVCTL_DEV</name>
+              <description>Device Mode</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFIFOSZ</name>
+          <description>USB Transmit Dynamic FIFO Sizing</description>
+          <addressOffset>0x00000062</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFIFOSZ_SIZE</name>
+              <description>Max Packet Size</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_8</name>
+                  <description>8</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_16</name>
+                  <description>16</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_32</name>
+                  <description>32</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_64</name>
+                  <description>64</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_128</name>
+                  <description>128</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_256</name>
+                  <description>256</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_512</name>
+                  <description>512</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_1024</name>
+                  <description>1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXFIFOSZ_SIZE_2048</name>
+                  <description>2048</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXFIFOSZ_DPB</name>
+              <description>Double Packet Buffer Support</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFIFOSZ</name>
+          <description>USB Receive Dynamic FIFO Sizing</description>
+          <addressOffset>0x00000063</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFIFOSZ_SIZE</name>
+              <description>Max Packet Size</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_8</name>
+                  <description>8</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_16</name>
+                  <description>16</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_32</name>
+                  <description>32</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_64</name>
+                  <description>64</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_128</name>
+                  <description>128</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_256</name>
+                  <description>256</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_512</name>
+                  <description>512</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_1024</name>
+                  <description>1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXFIFOSZ_SIZE_2048</name>
+                  <description>2048</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXFIFOSZ_DPB</name>
+              <description>Double Packet Buffer Support</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFIFOADD</name>
+          <description>USB Transmit FIFO Start Address</description>
+          <addressOffset>0x00000064</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXFIFOADD_ADDR</name>
+              <description>Transmit/Receive Start Address</description>
+              <bitRange>[8:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFIFOADD</name>
+          <description>USB Receive FIFO Start Address</description>
+          <addressOffset>0x00000066</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXFIFOADD_ADDR</name>
+              <description>Transmit/Receive Start Address</description>
+              <bitRange>[8:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONTIM</name>
+          <description>USB Connect Timing</description>
+          <addressOffset>0x0000007A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_CONTIM_WTID</name>
+              <description>Wait ID</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_CONTIM_WTCON</name>
+              <description>Connect Wait</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VPLEN</name>
+          <description>USB OTG VBUS Pulse Timing</description>
+          <addressOffset>0x0000007B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_VPLEN_VPLEN</name>
+              <description>VBUS Pulse Length</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSEOF</name>
+          <description>USB Full-Speed Last Transaction to End of Frame Timing</description>
+          <addressOffset>0x0000007D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_FSEOF_FSEOFG</name>
+              <description>Full-Speed End-of-Frame Gap</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LSEOF</name>
+          <description>USB Low-Speed Last Transaction to End of Frame Timing</description>
+          <addressOffset>0x0000007E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_LSEOF_LSEOFG</name>
+              <description>Low-Speed End-of-Frame Gap</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR0</name>
+          <description>USB Transmit Functional Address Endpoint 0</description>
+          <addressOffset>0x00000080</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR0_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR0</name>
+          <description>USB Transmit Hub Address Endpoint 0</description>
+          <addressOffset>0x00000082</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR0_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT0</name>
+          <description>USB Transmit Hub Port Endpoint 0</description>
+          <addressOffset>0x00000083</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT0_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR1</name>
+          <description>USB Transmit Functional Address Endpoint 1</description>
+          <addressOffset>0x00000088</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR1_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR1</name>
+          <description>USB Transmit Hub Address Endpoint 1</description>
+          <addressOffset>0x0000008A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR1_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT1</name>
+          <description>USB Transmit Hub Port Endpoint 1</description>
+          <addressOffset>0x0000008B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT1_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFUNCADDR1</name>
+          <description>USB Receive Functional Address Endpoint 1</description>
+          <addressOffset>0x0000008C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFUNCADDR1_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBADDR1</name>
+          <description>USB Receive Hub Address Endpoint 1</description>
+          <addressOffset>0x0000008E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBADDR1_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBPORT1</name>
+          <description>USB Receive Hub Port Endpoint 1</description>
+          <addressOffset>0x0000008F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBPORT1_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR2</name>
+          <description>USB Transmit Functional Address Endpoint 2</description>
+          <addressOffset>0x00000090</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR2_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR2</name>
+          <description>USB Transmit Hub Address Endpoint 2</description>
+          <addressOffset>0x00000092</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR2_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT2</name>
+          <description>USB Transmit Hub Port Endpoint 2</description>
+          <addressOffset>0x00000093</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT2_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFUNCADDR2</name>
+          <description>USB Receive Functional Address Endpoint 2</description>
+          <addressOffset>0x00000094</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFUNCADDR2_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBADDR2</name>
+          <description>USB Receive Hub Address Endpoint 2</description>
+          <addressOffset>0x00000096</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBADDR2_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBPORT2</name>
+          <description>USB Receive Hub Port Endpoint 2</description>
+          <addressOffset>0x00000097</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBPORT2_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR3</name>
+          <description>USB Transmit Functional Address Endpoint 3</description>
+          <addressOffset>0x00000098</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR3_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR3</name>
+          <description>USB Transmit Hub Address Endpoint 3</description>
+          <addressOffset>0x0000009A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR3_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT3</name>
+          <description>USB Transmit Hub Port Endpoint 3</description>
+          <addressOffset>0x0000009B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT3_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFUNCADDR3</name>
+          <description>USB Receive Functional Address Endpoint 3</description>
+          <addressOffset>0x0000009C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFUNCADDR3_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBADDR3</name>
+          <description>USB Receive Hub Address Endpoint 3</description>
+          <addressOffset>0x0000009E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBADDR3_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBPORT3</name>
+          <description>USB Receive Hub Port Endpoint 3</description>
+          <addressOffset>0x0000009F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBPORT3_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR4</name>
+          <description>USB Transmit Functional Address Endpoint 4</description>
+          <addressOffset>0x000000A0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR4_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR4</name>
+          <description>USB Transmit Hub Address Endpoint 4</description>
+          <addressOffset>0x000000A2</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR4_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT4</name>
+          <description>USB Transmit Hub Port Endpoint 4</description>
+          <addressOffset>0x000000A3</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT4_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFUNCADDR4</name>
+          <description>USB Receive Functional Address Endpoint 4</description>
+          <addressOffset>0x000000A4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFUNCADDR4_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBADDR4</name>
+          <description>USB Receive Hub Address Endpoint 4</description>
+          <addressOffset>0x000000A6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBADDR4_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBPORT4</name>
+          <description>USB Receive Hub Port Endpoint 4</description>
+          <addressOffset>0x000000A7</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBPORT4_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR5</name>
+          <description>USB Transmit Functional Address Endpoint 5</description>
+          <addressOffset>0x000000A8</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR5_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR5</name>
+          <description>USB Transmit Hub Address Endpoint 5</description>
+          <addressOffset>0x000000AA</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR5_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT5</name>
+          <description>USB Transmit Hub Port Endpoint 5</description>
+          <addressOffset>0x000000AB</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT5_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFUNCADDR5</name>
+          <description>USB Receive Functional Address Endpoint 5</description>
+          <addressOffset>0x000000AC</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFUNCADDR5_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBADDR5</name>
+          <description>USB Receive Hub Address Endpoint 5</description>
+          <addressOffset>0x000000AE</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBADDR5_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBPORT5</name>
+          <description>USB Receive Hub Port Endpoint 5</description>
+          <addressOffset>0x000000AF</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBPORT5_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR6</name>
+          <description>USB Transmit Functional Address Endpoint 6</description>
+          <addressOffset>0x000000B0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR6_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR6</name>
+          <description>USB Transmit Hub Address Endpoint 6</description>
+          <addressOffset>0x000000B2</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR6_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT6</name>
+          <description>USB Transmit Hub Port Endpoint 6</description>
+          <addressOffset>0x000000B3</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT6_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFUNCADDR6</name>
+          <description>USB Receive Functional Address Endpoint 6</description>
+          <addressOffset>0x000000B4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFUNCADDR6_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBADDR6</name>
+          <description>USB Receive Hub Address Endpoint 6</description>
+          <addressOffset>0x000000B6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBADDR6_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBPORT6</name>
+          <description>USB Receive Hub Port Endpoint 6</description>
+          <addressOffset>0x000000B7</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBPORT6_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXFUNCADDR7</name>
+          <description>USB Transmit Functional Address Endpoint 7</description>
+          <addressOffset>0x000000B8</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXFUNCADDR7_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBADDR7</name>
+          <description>USB Transmit Hub Address Endpoint 7</description>
+          <addressOffset>0x000000BA</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBADDR7_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXHUBPORT7</name>
+          <description>USB Transmit Hub Port Endpoint 7</description>
+          <addressOffset>0x000000BB</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXHUBPORT7_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXFUNCADDR7</name>
+          <description>USB Receive Functional Address Endpoint 7</description>
+          <addressOffset>0x000000BC</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXFUNCADDR7_ADDR</name>
+              <description>Device Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBADDR7</name>
+          <description>USB Receive Hub Address Endpoint 7</description>
+          <addressOffset>0x000000BE</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBADDR7_ADDR</name>
+              <description>Hub Address</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXHUBPORT7</name>
+          <description>USB Receive Hub Port Endpoint 7</description>
+          <addressOffset>0x000000BF</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXHUBPORT7_PORT</name>
+              <description>Hub Port</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSRL0</name>
+          <description>USB Control and Status Endpoint 0 Low</description>
+          <addressOffset>0x00000102</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>USB_CSRL0_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_DATAEND</name>
+              <description>Data End</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_SETEND</name>
+              <description>Setup End</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_STALL</name>
+              <description>Send Stall</description>
+              <bitRange>[5:5]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_RXRDYC</name>
+              <description>RXRDY Clear</description>
+              <bitRange>[6:6]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_SETENDC</name>
+              <description>Setup End Clear</description>
+              <bitRange>[7:7]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSRL0</name>
+          <description>USB Control and Status Endpoint 0 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000102</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>USB_CSRL0_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_ERROR</name>
+              <description>Error</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_STATUS</name>
+              <description>STATUS Packet</description>
+              <bitRange>[6:6]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRL0_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CSRH0</name>
+          <description>USB Control and Status Endpoint 0 High</description>
+          <addressOffset>0x00000103</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>USB_CSRH0_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRH0_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>USB_CSRH0_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT0</name>
+          <description>USB Receive Byte Count Endpoint 0</description>
+          <addressOffset>0x00000108</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_COUNT0_COUNT</name>
+              <description>FIFO Count</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TYPE0</name>
+          <description>USB Type Endpoint 0</description>
+          <addressOffset>0x0000010A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TYPE0_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TYPE0_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TYPE0_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NAKLMT</name>
+          <description>USB NAK Limit</description>
+          <addressOffset>0x0000010B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_NAKLMT_NAKLMT</name>
+              <description>EP0 NAK Limit</description>
+              <bitRange>[4:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXMAXP1</name>
+          <description>USB Maximum Transmit Data Endpoint 1</description>
+          <addressOffset>0x00000110</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXMAXP1_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL1</name>
+          <description>USB Transmit Control and Status Endpoint 1 Low</description>
+          <addressOffset>0x00000112</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL1_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_FIFONE</name>
+              <description>FIFO Not Empty</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL1</name>
+          <description>USB Transmit Control and Status Endpoint 1 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000112</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL1_UNDRN</name>
+              <description>Underrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL1_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRH1</name>
+          <description>USB Transmit Control and Status Endpoint 1 High</description>
+          <addressOffset>0x00000113</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRH1_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH1_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH1_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH1_FDT</name>
+              <description>Force Data Toggle</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH1_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH1_MODE</name>
+              <description>Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH1_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH1_AUTOSET</name>
+              <description>Auto Set</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXMAXP1</name>
+          <description>USB Maximum Receive Data Endpoint 1</description>
+          <addressOffset>0x00000114</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXMAXP1_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL1</name>
+          <description>USB Receive Control and Status Endpoint 1 Low</description>
+          <addressOffset>0x00000116</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL1_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_OVER</name>
+              <description>Overrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_DATAERR</name>
+              <description>Data Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL1</name>
+          <description>USB Receive Control and Status Endpoint 1 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000116</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL1_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL1_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH1</name>
+          <description>USB Receive Control and Status Endpoint 1 High</description>
+          <addressOffset>0x00000117</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH1_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH1_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH1_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH1_PIDERR</name>
+              <description>PID Error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH1_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH1_AUTORQ</name>
+              <description>Auto Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH1_AUTOCL</name>
+              <description>Auto Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH1</name>
+          <description>USB Receive Control and Status Endpoint 1 High</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000117</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH1_DISNYET</name>
+              <description>Disable NYET</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH1_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCOUNT1</name>
+          <description>USB Receive Byte Count Endpoint 1</description>
+          <addressOffset>0x00000118</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXCOUNT1_COUNT</name>
+              <description>Receive Packet Count</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXTYPE1</name>
+          <description>USB Host Transmit Configure Type Endpoint 1</description>
+          <addressOffset>0x0000011A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXTYPE1_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXTYPE1_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE1_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE1_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE1_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE1_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXTYPE1_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE1_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE1_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE1_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL1</name>
+          <description>USB Host Transmit Interval Endpoint 1</description>
+          <addressOffset>0x0000011B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL1_TXPOLL</name>
+              <description>TX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL1</name>
+          <description>USB Host Transmit Interval Endpoint 1</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000011B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL1_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXTYPE1</name>
+          <description>USB Host Configure Receive Type Endpoint 1</description>
+          <addressOffset>0x0000011C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXTYPE1_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXTYPE1_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE1_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE1_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE1_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE1_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXTYPE1_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE1_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE1_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE1_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL1</name>
+          <description>USB Host Receive Polling Interval Endpoint 1</description>
+          <addressOffset>0x0000011D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL1_TXPOLL</name>
+              <description>RX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL1</name>
+          <description>USB Host Receive Polling Interval Endpoint 1</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000011D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL1_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXMAXP2</name>
+          <description>USB Maximum Transmit Data Endpoint 2</description>
+          <addressOffset>0x00000120</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXMAXP2_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL2</name>
+          <description>USB Transmit Control and Status Endpoint 2 Low</description>
+          <addressOffset>0x00000122</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL2_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_FIFONE</name>
+              <description>FIFO Not Empty</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL2</name>
+          <description>USB Transmit Control and Status Endpoint 2 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000122</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL2_UNDRN</name>
+              <description>Underrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL2_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRH2</name>
+          <description>USB Transmit Control and Status Endpoint 2 High</description>
+          <addressOffset>0x00000123</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRH2_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH2_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH2_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH2_FDT</name>
+              <description>Force Data Toggle</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH2_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH2_MODE</name>
+              <description>Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH2_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH2_AUTOSET</name>
+              <description>Auto Set</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXMAXP2</name>
+          <description>USB Maximum Receive Data Endpoint 2</description>
+          <addressOffset>0x00000124</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXMAXP2_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL2</name>
+          <description>USB Receive Control and Status Endpoint 2 Low</description>
+          <addressOffset>0x00000126</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL2_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_OVER</name>
+              <description>Overrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_DATAERR</name>
+              <description>Data Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL2</name>
+          <description>USB Receive Control and Status Endpoint 2 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000126</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL2_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL2_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH2</name>
+          <description>USB Receive Control and Status Endpoint 2 High</description>
+          <addressOffset>0x00000127</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH2_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH2_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH2_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH2_PIDERR</name>
+              <description>PID Error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH2_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH2_AUTORQ</name>
+              <description>Auto Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH2_AUTOCL</name>
+              <description>Auto Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH2</name>
+          <description>USB Receive Control and Status Endpoint 2 High</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000127</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH2_DISNYET</name>
+              <description>Disable NYET</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH2_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCOUNT2</name>
+          <description>USB Receive Byte Count Endpoint 2</description>
+          <addressOffset>0x00000128</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXCOUNT2_COUNT</name>
+              <description>Receive Packet Count</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXTYPE2</name>
+          <description>USB Host Transmit Configure Type Endpoint 2</description>
+          <addressOffset>0x0000012A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXTYPE2_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXTYPE2_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE2_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE2_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE2_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE2_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXTYPE2_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE2_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE2_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE2_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL2</name>
+          <description>USB Host Transmit Interval Endpoint 2</description>
+          <addressOffset>0x0000012B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL2_TXPOLL</name>
+              <description>TX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL2</name>
+          <description>USB Host Transmit Interval Endpoint 2</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000012B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL2_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXTYPE2</name>
+          <description>USB Host Configure Receive Type Endpoint 2</description>
+          <addressOffset>0x0000012C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXTYPE2_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXTYPE2_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE2_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE2_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE2_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE2_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXTYPE2_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE2_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE2_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE2_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL2</name>
+          <description>USB Host Receive Polling Interval Endpoint 2</description>
+          <addressOffset>0x0000012D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL2_TXPOLL</name>
+              <description>RX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL2</name>
+          <description>USB Host Receive Polling Interval Endpoint 2</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000012D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL2_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXMAXP3</name>
+          <description>USB Maximum Transmit Data Endpoint 3</description>
+          <addressOffset>0x00000130</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXMAXP3_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL3</name>
+          <description>USB Transmit Control and Status Endpoint 3 Low</description>
+          <addressOffset>0x00000132</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL3_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_FIFONE</name>
+              <description>FIFO Not Empty</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL3</name>
+          <description>USB Transmit Control and Status Endpoint 3 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000132</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL3_UNDRN</name>
+              <description>Underrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL3_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRH3</name>
+          <description>USB Transmit Control and Status Endpoint 3 High</description>
+          <addressOffset>0x00000133</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRH3_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH3_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH3_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH3_FDT</name>
+              <description>Force Data Toggle</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH3_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH3_MODE</name>
+              <description>Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH3_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH3_AUTOSET</name>
+              <description>Auto Set</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXMAXP3</name>
+          <description>USB Maximum Receive Data Endpoint 3</description>
+          <addressOffset>0x00000134</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXMAXP3_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL3</name>
+          <description>USB Receive Control and Status Endpoint 3 Low</description>
+          <addressOffset>0x00000136</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL3_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_OVER</name>
+              <description>Overrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_DATAERR</name>
+              <description>Data Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL3</name>
+          <description>USB Receive Control and Status Endpoint 3 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000136</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL3_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL3_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH3</name>
+          <description>USB Receive Control and Status Endpoint 3 High</description>
+          <addressOffset>0x00000137</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH3_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH3_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH3_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH3_PIDERR</name>
+              <description>PID Error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH3_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH3_AUTORQ</name>
+              <description>Auto Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH3_AUTOCL</name>
+              <description>Auto Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH3</name>
+          <description>USB Receive Control and Status Endpoint 3 High</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000137</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH3_DISNYET</name>
+              <description>Disable NYET</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH3_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCOUNT3</name>
+          <description>USB Receive Byte Count Endpoint 3</description>
+          <addressOffset>0x00000138</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXCOUNT3_COUNT</name>
+              <description>Receive Packet Count</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXTYPE3</name>
+          <description>USB Host Transmit Configure Type Endpoint 3</description>
+          <addressOffset>0x0000013A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXTYPE3_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXTYPE3_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE3_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE3_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE3_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE3_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXTYPE3_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE3_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE3_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE3_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL3</name>
+          <description>USB Host Transmit Interval Endpoint 3</description>
+          <addressOffset>0x0000013B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL3_TXPOLL</name>
+              <description>TX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL3</name>
+          <description>USB Host Transmit Interval Endpoint 3</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000013B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL3_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXTYPE3</name>
+          <description>USB Host Configure Receive Type Endpoint 3</description>
+          <addressOffset>0x0000013C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXTYPE3_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXTYPE3_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE3_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE3_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE3_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE3_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXTYPE3_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE3_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE3_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE3_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL3</name>
+          <description>USB Host Receive Polling Interval Endpoint 3</description>
+          <addressOffset>0x0000013D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL3_TXPOLL</name>
+              <description>RX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL3</name>
+          <description>USB Host Receive Polling Interval Endpoint 3</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000013D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL3_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXMAXP4</name>
+          <description>USB Maximum Transmit Data Endpoint 4</description>
+          <addressOffset>0x00000140</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXMAXP4_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL4</name>
+          <description>USB Transmit Control and Status Endpoint 4 Low</description>
+          <addressOffset>0x00000142</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL4_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_FIFONE</name>
+              <description>FIFO Not Empty</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL4</name>
+          <description>USB Transmit Control and Status Endpoint 4 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000142</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL4_UNDRN</name>
+              <description>Underrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL4_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRH4</name>
+          <description>USB Transmit Control and Status Endpoint 4 High</description>
+          <addressOffset>0x00000143</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRH4_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH4_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH4_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH4_FDT</name>
+              <description>Force Data Toggle</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH4_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH4_MODE</name>
+              <description>Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH4_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH4_AUTOSET</name>
+              <description>Auto Set</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXMAXP4</name>
+          <description>USB Maximum Receive Data Endpoint 4</description>
+          <addressOffset>0x00000144</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXMAXP4_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL4</name>
+          <description>USB Receive Control and Status Endpoint 4 Low</description>
+          <addressOffset>0x00000146</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL4_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_OVER</name>
+              <description>Overrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_DATAERR</name>
+              <description>Data Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL4</name>
+          <description>USB Receive Control and Status Endpoint 4 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000146</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL4_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL4_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH4</name>
+          <description>USB Receive Control and Status Endpoint 4 High</description>
+          <addressOffset>0x00000147</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH4_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH4_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH4_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH4_PIDERR</name>
+              <description>PID Error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH4_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH4_AUTORQ</name>
+              <description>Auto Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH4_AUTOCL</name>
+              <description>Auto Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH4</name>
+          <description>USB Receive Control and Status Endpoint 4 High</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000147</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH4_DISNYET</name>
+              <description>Disable NYET</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH4_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCOUNT4</name>
+          <description>USB Receive Byte Count Endpoint 4</description>
+          <addressOffset>0x00000148</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXCOUNT4_COUNT</name>
+              <description>Receive Packet Count</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXTYPE4</name>
+          <description>USB Host Transmit Configure Type Endpoint 4</description>
+          <addressOffset>0x0000014A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXTYPE4_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXTYPE4_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE4_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE4_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE4_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE4_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXTYPE4_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE4_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE4_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE4_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL4</name>
+          <description>USB Host Transmit Interval Endpoint 4</description>
+          <addressOffset>0x0000014B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL4_TXPOLL</name>
+              <description>TX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL4</name>
+          <description>USB Host Transmit Interval Endpoint 4</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000014B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL4_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXTYPE4</name>
+          <description>USB Host Configure Receive Type Endpoint 4</description>
+          <addressOffset>0x0000014C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXTYPE4_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXTYPE4_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE4_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE4_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE4_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE4_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXTYPE4_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE4_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE4_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE4_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL4</name>
+          <description>USB Host Receive Polling Interval Endpoint 4</description>
+          <addressOffset>0x0000014D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL4_TXPOLL</name>
+              <description>RX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL4</name>
+          <description>USB Host Receive Polling Interval Endpoint 4</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000014D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL4_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXMAXP5</name>
+          <description>USB Maximum Transmit Data Endpoint 5</description>
+          <addressOffset>0x00000150</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXMAXP5_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL5</name>
+          <description>USB Transmit Control and Status Endpoint 5 Low</description>
+          <addressOffset>0x00000152</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL5_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_FIFONE</name>
+              <description>FIFO Not Empty</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL5</name>
+          <description>USB Transmit Control and Status Endpoint 5 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000152</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL5_UNDRN</name>
+              <description>Underrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL5_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRH5</name>
+          <description>USB Transmit Control and Status Endpoint 5 High</description>
+          <addressOffset>0x00000153</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRH5_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH5_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH5_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH5_FDT</name>
+              <description>Force Data Toggle</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH5_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH5_MODE</name>
+              <description>Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH5_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH5_AUTOSET</name>
+              <description>Auto Set</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXMAXP5</name>
+          <description>USB Maximum Receive Data Endpoint 5</description>
+          <addressOffset>0x00000154</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXMAXP5_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL5</name>
+          <description>USB Receive Control and Status Endpoint 5 Low</description>
+          <addressOffset>0x00000156</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL5_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_OVER</name>
+              <description>Overrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_DATAERR</name>
+              <description>Data Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL5</name>
+          <description>USB Receive Control and Status Endpoint 5 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000156</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL5_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL5_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH5</name>
+          <description>USB Receive Control and Status Endpoint 5 High</description>
+          <addressOffset>0x00000157</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH5_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH5_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH5_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH5_PIDERR</name>
+              <description>PID Error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH5_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH5_AUTORQ</name>
+              <description>Auto Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH5_AUTOCL</name>
+              <description>Auto Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH5</name>
+          <description>USB Receive Control and Status Endpoint 5 High</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000157</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH5_DISNYET</name>
+              <description>Disable NYET</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH5_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCOUNT5</name>
+          <description>USB Receive Byte Count Endpoint 5</description>
+          <addressOffset>0x00000158</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXCOUNT5_COUNT</name>
+              <description>Receive Packet Count</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXTYPE5</name>
+          <description>USB Host Transmit Configure Type Endpoint 5</description>
+          <addressOffset>0x0000015A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXTYPE5_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXTYPE5_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE5_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE5_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE5_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE5_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXTYPE5_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE5_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE5_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE5_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL5</name>
+          <description>USB Host Transmit Interval Endpoint 5</description>
+          <addressOffset>0x0000015B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL5_TXPOLL</name>
+              <description>TX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL5</name>
+          <description>USB Host Transmit Interval Endpoint 5</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000015B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL5_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXTYPE5</name>
+          <description>USB Host Configure Receive Type Endpoint 5</description>
+          <addressOffset>0x0000015C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXTYPE5_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXTYPE5_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE5_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE5_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE5_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE5_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXTYPE5_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE5_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE5_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE5_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL5</name>
+          <description>USB Host Receive Polling Interval Endpoint 5</description>
+          <addressOffset>0x0000015D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL5_TXPOLL</name>
+              <description>RX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL5</name>
+          <description>USB Host Receive Polling Interval Endpoint 5</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000015D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL5_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXMAXP6</name>
+          <description>USB Maximum Transmit Data Endpoint 6</description>
+          <addressOffset>0x00000160</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXMAXP6_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL6</name>
+          <description>USB Transmit Control and Status Endpoint 6 Low</description>
+          <addressOffset>0x00000162</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL6_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_FIFONE</name>
+              <description>FIFO Not Empty</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL6</name>
+          <description>USB Transmit Control and Status Endpoint 6 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000162</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL6_UNDRN</name>
+              <description>Underrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL6_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRH6</name>
+          <description>USB Transmit Control and Status Endpoint 6 High</description>
+          <addressOffset>0x00000163</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRH6_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH6_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH6_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH6_FDT</name>
+              <description>Force Data Toggle</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH6_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH6_MODE</name>
+              <description>Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH6_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH6_AUTOSET</name>
+              <description>Auto Set</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXMAXP6</name>
+          <description>USB Maximum Receive Data Endpoint 6</description>
+          <addressOffset>0x00000164</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXMAXP6_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL6</name>
+          <description>USB Receive Control and Status Endpoint 6 Low</description>
+          <addressOffset>0x00000166</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL6_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_OVER</name>
+              <description>Overrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_DATAERR</name>
+              <description>Data Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL6</name>
+          <description>USB Receive Control and Status Endpoint 6 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000166</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL6_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL6_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH6</name>
+          <description>USB Receive Control and Status Endpoint 6 High</description>
+          <addressOffset>0x00000167</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH6_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH6_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH6_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH6_PIDERR</name>
+              <description>PID Error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH6_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH6_AUTORQ</name>
+              <description>Auto Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH6_AUTOCL</name>
+              <description>Auto Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH6</name>
+          <description>USB Receive Control and Status Endpoint 6 High</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000167</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH6_DISNYET</name>
+              <description>Disable NYET</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH6_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCOUNT6</name>
+          <description>USB Receive Byte Count Endpoint 6</description>
+          <addressOffset>0x00000168</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXCOUNT6_COUNT</name>
+              <description>Receive Packet Count</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXTYPE6</name>
+          <description>USB Host Transmit Configure Type Endpoint 6</description>
+          <addressOffset>0x0000016A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXTYPE6_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXTYPE6_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE6_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE6_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE6_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE6_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXTYPE6_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE6_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE6_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE6_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL6</name>
+          <description>USB Host Transmit Interval Endpoint 6</description>
+          <addressOffset>0x0000016B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL6_TXPOLL</name>
+              <description>TX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL6</name>
+          <description>USB Host Transmit Interval Endpoint 6</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000016B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL6_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXTYPE6</name>
+          <description>USB Host Configure Receive Type Endpoint 6</description>
+          <addressOffset>0x0000016C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXTYPE6_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXTYPE6_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE6_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE6_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE6_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE6_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXTYPE6_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE6_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE6_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE6_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL6</name>
+          <description>USB Host Receive Polling Interval Endpoint 6</description>
+          <addressOffset>0x0000016D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL6_TXPOLL</name>
+              <description>RX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL6</name>
+          <description>USB Host Receive Polling Interval Endpoint 6</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000016D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL6_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXMAXP7</name>
+          <description>USB Maximum Transmit Data Endpoint 7</description>
+          <addressOffset>0x00000170</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXMAXP7_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL7</name>
+          <description>USB Transmit Control and Status Endpoint 7 Low</description>
+          <addressOffset>0x00000172</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL7_TXRDY</name>
+              <description>Transmit Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_FIFONE</name>
+              <description>FIFO Not Empty</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_SETUP</name>
+              <description>Setup Packet</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRL7</name>
+          <description>USB Transmit Control and Status Endpoint 7 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000172</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRL7_UNDRN</name>
+              <description>Underrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRL7_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXCSRH7</name>
+          <description>USB Transmit Control and Status Endpoint 7 High</description>
+          <addressOffset>0x00000173</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXCSRH7_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH7_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH7_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH7_FDT</name>
+              <description>Force Data Toggle</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH7_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH7_MODE</name>
+              <description>Mode</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH7_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXCSRH7_AUTOSET</name>
+              <description>Auto Set</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXMAXP7</name>
+          <description>USB Maximum Receive Data Endpoint 7</description>
+          <addressOffset>0x00000174</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXMAXP7_MAXLOAD</name>
+              <description>Maximum Payload</description>
+              <bitRange>[10:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL7</name>
+          <description>USB Receive Control and Status Endpoint 7 Low</description>
+          <addressOffset>0x00000176</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL7_RXRDY</name>
+              <description>Receive Packet Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_FULL</name>
+              <description>FIFO Full</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_OVER</name>
+              <description>Overrun</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_DATAERR</name>
+              <description>Data Error</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_FLUSH</name>
+              <description>Flush FIFO</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_STALL</name>
+              <description>Send STALL</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_STALLED</name>
+              <description>Endpoint Stalled</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_CLRDT</name>
+              <description>Clear Data Toggle</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRL7</name>
+          <description>USB Receive Control and Status Endpoint 7 Low</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000176</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRL7_ERROR</name>
+              <description>Error</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_NAKTO</name>
+              <description>NAK Timeout</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRL7_REQPKT</name>
+              <description>Request Packet</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH7</name>
+          <description>USB Receive Control and Status Endpoint 7 High</description>
+          <addressOffset>0x00000177</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH7_DT</name>
+              <description>Data Toggle</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH7_DTWE</name>
+              <description>Data Toggle Write Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH7_DMAMOD</name>
+              <description>DMA Request Mode</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH7_PIDERR</name>
+              <description>PID Error</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH7_DMAEN</name>
+              <description>DMA Request Enable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH7_AUTORQ</name>
+              <description>Auto Request</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH7_AUTOCL</name>
+              <description>Auto Clear</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCSRH7</name>
+          <description>USB Receive Control and Status Endpoint 7 High</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x00000177</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXCSRH7_DISNYET</name>
+              <description>Disable NYET</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXCSRH7_ISO</name>
+              <description>Isochronous Transfers</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXCOUNT7</name>
+          <description>USB Receive Byte Count Endpoint 7</description>
+          <addressOffset>0x00000178</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXCOUNT7_COUNT</name>
+              <description>Receive Packet Count</description>
+              <bitRange>[12:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXTYPE7</name>
+          <description>USB Host Transmit Configure Type Endpoint 7</description>
+          <addressOffset>0x0000017A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXTYPE7_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXTYPE7_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE7_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE7_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE7_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE7_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_TXTYPE7_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_TXTYPE7_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE7_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_TXTYPE7_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL7</name>
+          <description>USB Host Transmit Interval Endpoint 7</description>
+          <addressOffset>0x0000017B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL7_TXPOLL</name>
+              <description>TX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXINTERVAL7</name>
+          <description>USB Host Transmit Interval Endpoint 7</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000017B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_TXINTERVAL7_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXTYPE7</name>
+          <description>USB Host Configure Receive Type Endpoint 7</description>
+          <addressOffset>0x0000017C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXTYPE7_TEP</name>
+              <description>Target Endpoint Number</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXTYPE7_PROTO</name>
+              <description>Protocol</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE7_PROTO_CTRL</name>
+                  <description>Control</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE7_PROTO_ISOC</name>
+                  <description>Isochronous</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE7_PROTO_BULK</name>
+                  <description>Bulk</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE7_PROTO_INT</name>
+                  <description>Interrupt</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_RXTYPE7_SPEED</name>
+              <description>Operating Speed</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_RXTYPE7_SPEED_DFLT</name>
+                  <description>Default</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE7_SPEED_FULL</name>
+                  <description>Full</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_RXTYPE7_SPEED_LOW</name>
+                  <description>Low</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL7</name>
+          <description>USB Host Receive Polling Interval Endpoint 7</description>
+          <addressOffset>0x0000017D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL7_TXPOLL</name>
+              <description>RX Polling</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXINTERVAL7</name>
+          <description>USB Host Receive Polling Interval Endpoint 7</description>
+          <alternateGroup>USB0_ALT</alternateGroup>
+          <addressOffset>0x0000017D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>USB_RXINTERVAL7_NAKLMT</name>
+              <description>NAK Limit</description>
+              <bitRange>[7:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RQPKTCOUNT1</name>
+          <description>USB Request Packet Count in Block Transfer Endpoint 1</description>
+          <addressOffset>0x00000304</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RQPKTCOUNT1</name>
+              <description>Block Transfer Packet Count</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RQPKTCOUNT2</name>
+          <description>USB Request Packet Count in Block Transfer Endpoint 2</description>
+          <addressOffset>0x00000308</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RQPKTCOUNT2</name>
+              <description>Block Transfer Packet Count</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RQPKTCOUNT3</name>
+          <description>USB Request Packet Count in Block Transfer Endpoint 3</description>
+          <addressOffset>0x0000030C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RQPKTCOUNT3</name>
+              <description>Block Transfer Packet Count</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RQPKTCOUNT4</name>
+          <description>USB Request Packet Count in Block Transfer Endpoint 4</description>
+          <addressOffset>0x00000310</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RQPKTCOUNT4_COUNT</name>
+              <description>Block Transfer Packet Count</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RQPKTCOUNT5</name>
+          <description>USB Request Packet Count in Block Transfer Endpoint 5</description>
+          <addressOffset>0x00000314</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RQPKTCOUNT5_COUNT</name>
+              <description>Block Transfer Packet Count</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RQPKTCOUNT6</name>
+          <description>USB Request Packet Count in Block Transfer Endpoint 6</description>
+          <addressOffset>0x00000318</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RQPKTCOUNT6_COUNT</name>
+              <description>Block Transfer Packet Count</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RQPKTCOUNT7</name>
+          <description>USB Request Packet Count in Block Transfer Endpoint 7</description>
+          <addressOffset>0x0000031C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RQPKTCOUNT7_COUNT</name>
+              <description>Block Transfer Packet Count</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXDPKTBUFDIS</name>
+          <description>USB Receive Double Packet Buffer Disable</description>
+          <addressOffset>0x00000340</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_RXDPKTBUFDIS_EP1</name>
+              <description>EP1 RX Double-Packet Buffer Disable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXDPKTBUFDIS_EP2</name>
+              <description>EP2 RX Double-Packet Buffer Disable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXDPKTBUFDIS_EP3</name>
+              <description>EP3 RX Double-Packet Buffer Disable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXDPKTBUFDIS_EP4</name>
+              <description>EP4 RX Double-Packet Buffer Disable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXDPKTBUFDIS_EP5</name>
+              <description>EP5 RX Double-Packet Buffer Disable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXDPKTBUFDIS_EP6</name>
+              <description>EP6 RX Double-Packet Buffer Disable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_RXDPKTBUFDIS_EP7</name>
+              <description>EP7 RX Double-Packet Buffer Disable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TXDPKTBUFDIS</name>
+          <description>USB Transmit Double Packet Buffer Disable</description>
+          <addressOffset>0x00000342</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USB_TXDPKTBUFDIS_EP1</name>
+              <description>EP1 TX Double-Packet Buffer Disable</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXDPKTBUFDIS_EP2</name>
+              <description>EP2 TX Double-Packet Buffer Disable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXDPKTBUFDIS_EP3</name>
+              <description>EP3 TX Double-Packet Buffer Disable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXDPKTBUFDIS_EP4</name>
+              <description>EP4 TX Double-Packet Buffer Disable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXDPKTBUFDIS_EP5</name>
+              <description>EP5 TX Double-Packet Buffer Disable</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXDPKTBUFDIS_EP6</name>
+              <description>EP6 TX Double-Packet Buffer Disable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_TXDPKTBUFDIS_EP7</name>
+              <description>EP7 TX Double-Packet Buffer Disable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPC</name>
+          <description>USB External Power Control</description>
+          <addressOffset>0x00000400</addressOffset>
+          <fields>
+            <field>
+              <name>USB_EPC_EPEN</name>
+              <description>External Power Supply Enable Configuration</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_EPC_EPEN_LOW</name>
+                  <description>Power Enable Active Low</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_EPC_EPEN_HIGH</name>
+                  <description>Power Enable Active High</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_EPC_EPEN_VBLOW</name>
+                  <description>Power Enable High if VBUS Low</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_EPC_EPEN_VBHIGH</name>
+                  <description>Power Enable High if VBUS High</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_EPC_EPENDE</name>
+              <description>EPEN Drive Enable</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>USB_EPC_PFLTEN</name>
+              <description>Power Fault Input Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_EPC_PFLTSEN_HIGH</name>
+              <description>Power Fault Sense</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>USB_EPC_PFLTAEN</name>
+              <description>Power Fault Action Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>USB_EPC_PFLTACT</name>
+              <description>Power Fault Action</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_EPC_PFLTACT_UNCHG</name>
+                  <description>Unchanged</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_EPC_PFLTACT_TRIS</name>
+                  <description>Tristate</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_EPC_PFLTACT_LOW</name>
+                  <description>Low</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_EPC_PFLTACT_HIGH</name>
+                  <description>High</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPCRIS</name>
+          <description>USB External Power Control Raw Interrupt Status</description>
+          <addressOffset>0x00000404</addressOffset>
+          <fields>
+            <field>
+              <name>USB_EPCRIS_PF</name>
+              <description>USB Power Fault Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPCIM</name>
+          <description>USB External Power Control Interrupt Mask</description>
+          <addressOffset>0x00000408</addressOffset>
+          <fields>
+            <field>
+              <name>USB_EPCIM_PF</name>
+              <description>USB Power Fault Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPCISC</name>
+          <description>USB External Power Control Interrupt Status and Clear</description>
+          <addressOffset>0x0000040C</addressOffset>
+          <fields>
+            <field>
+              <name>USB_EPCISC_PF</name>
+              <description>USB Power Fault Interrupt Status and Clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRRIS</name>
+          <description>USB Device RESUME Raw Interrupt Status</description>
+          <addressOffset>0x00000410</addressOffset>
+          <fields>
+            <field>
+              <name>USB_DRRIS_RESUME</name>
+              <description>RESUME Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRIM</name>
+          <description>USB Device RESUME Interrupt Mask</description>
+          <addressOffset>0x00000414</addressOffset>
+          <fields>
+            <field>
+              <name>USB_DRIM_RESUME</name>
+              <description>RESUME Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRISC</name>
+          <description>USB Device RESUME Interrupt Status and Clear</description>
+          <addressOffset>0x00000418</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>USB_DRISC_RESUME</name>
+              <description>RESUME Interrupt Status and Clear</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPCS</name>
+          <description>USB General-Purpose Control and Status</description>
+          <addressOffset>0x0000041C</addressOffset>
+          <fields>
+            <field>
+              <name>USB_GPCS_DEVMOD</name>
+              <description>Device Mode</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_GPCS_DEVMODOTG</name>
+              <description>Enable Device Mode</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VDC</name>
+          <description>USB VBUS Droop Control</description>
+          <addressOffset>0x00000430</addressOffset>
+          <fields>
+            <field>
+              <name>USB_VDC_VBDEN</name>
+              <description>VBUS Droop Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VDCRIS</name>
+          <description>USB VBUS Droop Control Raw Interrupt Status</description>
+          <addressOffset>0x00000434</addressOffset>
+          <fields>
+            <field>
+              <name>USB_VDCRIS_VD</name>
+              <description>VBUS Droop Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VDCIM</name>
+          <description>USB VBUS Droop Control Interrupt Mask</description>
+          <addressOffset>0x00000438</addressOffset>
+          <fields>
+            <field>
+              <name>USB_VDCIM_VD</name>
+              <description>VBUS Droop Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VDCISC</name>
+          <description>USB VBUS Droop Control Interrupt Status and Clear</description>
+          <addressOffset>0x0000043C</addressOffset>
+          <fields>
+            <field>
+              <name>USB_VDCISC_VD</name>
+              <description>VBUS Droop Interrupt Status and Clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDVRIS</name>
+          <description>USB ID Valid Detect Raw Interrupt Status</description>
+          <addressOffset>0x00000444</addressOffset>
+          <fields>
+            <field>
+              <name>USB_IDVRIS_ID</name>
+              <description>ID Valid Detect Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDVIM</name>
+          <description>USB ID Valid Detect Interrupt Mask</description>
+          <addressOffset>0x00000448</addressOffset>
+          <fields>
+            <field>
+              <name>USB_IDVIM_ID</name>
+              <description>ID Valid Detect Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDVISC</name>
+          <description>USB ID Valid Detect Interrupt Status and Clear</description>
+          <addressOffset>0x0000044C</addressOffset>
+          <fields>
+            <field>
+              <name>USB_IDVISC_ID</name>
+              <description>ID Valid Detect Interrupt Status and Clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DMASEL</name>
+          <description>USB DMA Select</description>
+          <addressOffset>0x00000450</addressOffset>
+          <fields>
+            <field>
+              <name>USB_DMASEL_DMAARX</name>
+              <description>DMA A RX Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>USB_DMASEL_DMAATX</name>
+              <description>DMA A TX Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_DMASEL_DMABRX</name>
+              <description>DMA B RX Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>USB_DMASEL_DMABTX</name>
+              <description>DMA B TX Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>USB_DMASEL_DMACRX</name>
+              <description>DMA C RX Select</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>USB_DMASEL_DMACTX</name>
+              <description>DMA C TX Select</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>USB Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>USB_PP_TYPE</name>
+              <description>Controller Type</description>
+              <bitRange>[3:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_PP_TYPE_0</name>
+                  <description>The first-generation USB controller</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_PP_PHY</name>
+              <description>PHY Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>USB_PP_USB</name>
+              <description>USB Capability</description>
+              <bitRange>[7:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>USB_PP_USB_DEVICE</name>
+                  <description>DEVICE</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_PP_USB_HOSTDEVICE</name>
+                  <description>HOST</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB_PP_USB_OTG</name>
+                  <description>OTG</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>USB_PP_ECNT</name>
+              <description>Endpoint Count</description>
+              <bitRange>[15:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOA_AHB</name>
+      <prependToName>GPIOA_AHB</prependToName>
+      <baseAddress>0x40058000</baseAddress>
+      <interrupt><name>GPIOA</name><value>0</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB_AHB</name>
+      <prependToName>GPIOB_AHB</prependToName>
+      <baseAddress>0x40059000</baseAddress>
+      <interrupt><name>GPIOB</name><value>1</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOC_AHB</name>
+      <prependToName>GPIOC_AHB</prependToName>
+      <baseAddress>0x4005A000</baseAddress>
+      <interrupt><name>GPIOC</name><value>2</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOD_AHB</name>
+      <prependToName>GPIOD_AHB</prependToName>
+      <baseAddress>0x4005B000</baseAddress>
+      <interrupt><name>GPIOD</name><value>3</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOE_AHB</name>
+      <prependToName>GPIOE_AHB</prependToName>
+      <baseAddress>0x4005C000</baseAddress>
+      <interrupt><name>GPIOE</name><value>4</value></interrupt>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOF_AHB</name>
+      <prependToName>GPIOF_AHB</prependToName>
+      <baseAddress>0x4005D000</baseAddress>
+      <interrupt><name>GPIOF</name><value>30</value></interrupt>
+    </peripheral>
+    <peripheral>
+      <name>EEPROM</name>
+      <description>Register map for EEPROM peripheral</description>
+      <groupName>EEPROM</groupName>
+      <prependToName>EEPROM</prependToName>
+      <baseAddress>0x400AF000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>EESIZE</name>
+          <description>EEPROM Size Information</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EESIZE_WORDCNT</name>
+              <description>Number of 32-Bit Words</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EESIZE_BLKCNT</name>
+              <description>Number of 16-Word Blocks</description>
+              <bitRange>[26:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEBLOCK</name>
+          <description>EEPROM Current Block</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEBLOCK_BLOCK</name>
+              <description>Current Block</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEOFFSET</name>
+          <description>EEPROM Current Offset</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEOFFSET_OFFSET</name>
+              <description>Current Address Offset</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EERDWR</name>
+          <description>EEPROM Read-Write</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EERDWR_VALUE</name>
+              <description>EEPROM Read or Write Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EERDWRINC</name>
+          <description>EEPROM Read-Write with Increment</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EERDWRINC_VALUE</name>
+              <description>EEPROM Read or Write Data with Increment</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEDONE</name>
+          <description>EEPROM Done Status</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEDONE_WORKING</name>
+              <description>EEPROM Working</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EEDONE_WKERASE</name>
+              <description>Working on an Erase</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EEDONE_WKCOPY</name>
+              <description>Working on a Copy</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EEDONE_NOPERM</name>
+              <description>Write Without Permission</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EEDONE_WRBUSY</name>
+              <description>Write Busy</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EEDONE_INVPL</name>
+              <description>Invalid Program Voltage Level</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EESUPP</name>
+          <description>EEPROM Support Control and Status</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EESUPP_START</name>
+              <description>Start Erase</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EESUPP_EREQ</name>
+              <description>Erase Required</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EESUPP_ERETRY</name>
+              <description>Erase Must Be Retried</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EESUPP_PRETRY</name>
+              <description>Programming Must Be Retried</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEUNLOCK</name>
+          <description>EEPROM Unlock</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEUNLOCK_UNLOCK</name>
+              <description>EEPROM Unlock</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEPROT</name>
+          <description>EEPROM Protection</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEPROT_PROT</name>
+              <description>Protection Control</description>
+              <bitRange>[2:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>EEPROM_EEPROT_PROT_RWNPW</name>
+                  <description>This setting is the default. If there is no password, the block is not protected and is readable and writable</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EEPROM_EEPROT_PROT_RWPW</name>
+                  <description>If there is a password, the block is readable or writable only when unlocked</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EEPROM_EEPROT_PROT_RONPW</name>
+                  <description>If there is no password, the block is readable, not writable</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EEPROM_EEPROT_ACC</name>
+              <description>Access Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEPASS0</name>
+          <description>EEPROM Password</description>
+          <addressOffset>0x00000034</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEPASS0_PASS</name>
+              <description>Password</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEPASS1</name>
+          <description>EEPROM Password</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEPASS1_PASS</name>
+              <description>Password</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEPASS2</name>
+          <description>EEPROM Password</description>
+          <addressOffset>0x0000003C</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEPASS2_PASS</name>
+              <description>Password</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEINT</name>
+          <description>EEPROM Interrupt</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEINT_INT</name>
+              <description>Interrupt Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEHIDE</name>
+          <description>EEPROM Block Hide</description>
+          <addressOffset>0x00000050</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEHIDE_HN</name>
+              <description>Hide Block</description>
+              <bitRange>[31:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EEDBGME</name>
+          <description>EEPROM Debug Mass Erase</description>
+          <addressOffset>0x00000080</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_EEDBGME_ME</name>
+              <description>Mass Erase</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>EEPROM_EEDBGME_KEY</name>
+              <description>Erase Key</description>
+              <bitRange>[31:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PP</name>
+          <description>EEPROM Peripheral Properties</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>EEPROM_PP_SIZE</name>
+              <description>EEPROM Size</description>
+              <bitRange>[4:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SYSEXC</name>
+      <description>Register map for SYSEXC peripheral</description>
+      <groupName>SYSEXC</groupName>
+      <prependToName>SYSEXC</prependToName>
+      <baseAddress>0x400F9000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>SYSEXC</name><value>106</value></interrupt>
+      <registers>
+        <register>
+          <name>RIS</name>
+          <description>System Exception Raw Interrupt Status</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>SYSEXC_RIS_FPIDCRIS</name>
+              <description>Floating-Point Input Denormal Exception Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_RIS_FPDZCRIS</name>
+              <description>Floating-Point Divide By 0 Exception Raw Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_RIS_FPIOCRIS</name>
+              <description>Floating-Point Invalid Operation Raw Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_RIS_FPUFCRIS</name>
+              <description>Floating-Point Underflow Exception Raw Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_RIS_FPOFCRIS</name>
+              <description>Floating-Point Overflow Exception Raw Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_RIS_FPIXCRIS</name>
+              <description>Floating-Point Inexact Exception Raw Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IM</name>
+          <description>System Exception Interrupt Mask</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>SYSEXC_IM_FPIDCIM</name>
+              <description>Floating-Point Input Denormal Exception Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_IM_FPDZCIM</name>
+              <description>Floating-Point Divide By 0 Exception Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_IM_FPIOCIM</name>
+              <description>Floating-Point Invalid Operation Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_IM_FPUFCIM</name>
+              <description>Floating-Point Underflow Exception Interrupt Mask</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_IM_FPOFCIM</name>
+              <description>Floating-Point Overflow Exception Interrupt Mask</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_IM_FPIXCIM</name>
+              <description>Floating-Point Inexact Exception Interrupt Mask</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>System Exception Masked Interrupt Status</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>SYSEXC_MIS_FPIDCMIS</name>
+              <description>Floating-Point Input Denormal Exception Masked Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_MIS_FPDZCMIS</name>
+              <description>Floating-Point Divide By 0 Exception Masked Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_MIS_FPIOCMIS</name>
+              <description>Floating-Point Invalid Operation Masked Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_MIS_FPUFCMIS</name>
+              <description>Floating-Point Underflow Exception Masked Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_MIS_FPOFCMIS</name>
+              <description>Floating-Point Overflow Exception Masked Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSEXC_MIS_FPIXCMIS</name>
+              <description>Floating-Point Inexact Exception Masked Interrupt Status</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IC</name>
+          <description>System Exception Interrupt Clear</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SYSEXC_IC_FPIDCIC</name>
+              <description>Floating-Point Input Denormal Exception Interrupt Clear</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SYSEXC_IC_FPDZCIC</name>
+              <description>Floating-Point Divide By 0 Exception Interrupt Clear</description>
+              <bitRange>[1:1]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SYSEXC_IC_FPIOCIC</name>
+              <description>Floating-Point Invalid Operation Interrupt Clear</description>
+              <bitRange>[2:2]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SYSEXC_IC_FPUFCIC</name>
+              <description>Floating-Point Underflow Exception Interrupt Clear</description>
+              <bitRange>[3:3]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SYSEXC_IC_FPOFCIC</name>
+              <description>Floating-Point Overflow Exception Interrupt Clear</description>
+              <bitRange>[4:4]</bitRange>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SYSEXC_IC_FPIXCIC</name>
+              <description>Floating-Point Inexact Exception Interrupt Clear</description>
+              <bitRange>[5:5]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>HIB</name>
+      <description>Register map for HIB peripheral</description>
+      <groupName>HIB</groupName>
+      <prependToName>HIB</prependToName>
+      <baseAddress>0x400FC000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>HIB</name><value>43</value></interrupt>
+      <registers>
+        <register>
+          <name>RTCC</name>
+          <description>Hibernation RTC Counter</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_RTCC</name>
+              <description>RTC Counter</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RTCM0</name>
+          <description>Hibernation RTC Match 0</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_RTCM0</name>
+              <description>RTC Match 0</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RTCLD</name>
+          <description>Hibernation RTC Load</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_RTCLD</name>
+              <description>RTC Load</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTL</name>
+          <description>Hibernation Control</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_CTL_RTCEN</name>
+              <description>RTC Timer Enable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_HIBREQ</name>
+              <description>Hibernation Request</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_RTCWEN</name>
+              <description>RTC Wake-up Enable</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_PINWEN</name>
+              <description>External WAKE Pin Enable</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_CLK32EN</name>
+              <description>Clocking Enable</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_VABORT</name>
+              <description>Power Cut Abort Enable</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_VDD3ON</name>
+              <description>VDD Powered</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_BATWKEN</name>
+              <description>Wake on Low Battery</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_BATCHK</name>
+              <description>Check Battery Status</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_VBATSEL</name>
+              <description>Select for Low-Battery Comparator</description>
+              <bitRange>[14:13]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>HIB_CTL_VBATSEL_1_9V</name>
+                  <description>1.9 Volts</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIB_CTL_VBATSEL_2_1V</name>
+                  <description>2.1 Volts (default)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIB_CTL_VBATSEL_2_3V</name>
+                  <description>2.3 Volts</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIB_CTL_VBATSEL_2_5V</name>
+                  <description>2.5 Volts</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>HIB_CTL_OSCBYP</name>
+              <description>Oscillator Bypass</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_OSCDRV</name>
+              <description>Oscillator Drive Capability</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>HIB_CTL_WRC</name>
+              <description>Write Complete/Capable</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IM</name>
+          <description>Hibernation Interrupt Mask</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_IM_RTCALT0</name>
+              <description>RTC Alert 0 Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>HIB_IM_LOWBAT</name>
+              <description>Low Battery Voltage Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>HIB_IM_EXTW</name>
+              <description>External Wake-Up Interrupt Mask</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>HIB_IM_WC</name>
+              <description>External Write Complete/Capable Interrupt Mask</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>Hibernation Raw Interrupt Status</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_RIS_RTCALT0</name>
+              <description>RTC Alert 0 Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>HIB_RIS_LOWBAT</name>
+              <description>Low Battery Voltage Raw Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>HIB_RIS_EXTW</name>
+              <description>External Wake-Up Raw Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>HIB_RIS_WC</name>
+              <description>Write Complete/Capable Raw Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS</name>
+          <description>Hibernation Masked Interrupt Status</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_MIS_RTCALT0</name>
+              <description>RTC Alert 0 Masked Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>HIB_MIS_LOWBAT</name>
+              <description>Low Battery Voltage Masked Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>HIB_MIS_EXTW</name>
+              <description>External Wake-Up Masked Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>HIB_MIS_WC</name>
+              <description>Write Complete/Capable Masked Interrupt Status</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IC</name>
+          <description>Hibernation Interrupt Clear</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_IC_RTCALT0</name>
+              <description>RTC Alert0 Masked Interrupt Clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>HIB_IC_LOWBAT</name>
+              <description>Low Battery Voltage Masked Interrupt Clear</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>HIB_IC_EXTW</name>
+              <description>External Wake-Up Masked Interrupt Clear</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>HIB_IC_WC</name>
+              <description>Write Complete/Capable Masked Interrupt Clear</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RTCT</name>
+          <description>Hibernation RTC Trim</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_RTCT_TRIM</name>
+              <description>RTC Trim Value</description>
+              <bitRange>[15:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RTCSS</name>
+          <description>Hibernation RTC Sub Seconds</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_RTCSS_RTCSSC</name>
+              <description>RTC Sub Seconds Count</description>
+              <bitRange>[14:0]</bitRange>
+            </field>
+            <field>
+              <name>HIB_RTCSS_RTCSSM</name>
+              <description>RTC Sub Seconds Match</description>
+              <bitRange>[30:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Hibernation Data</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>HIB_DATA_RTD</name>
+              <description>Hibernation Module NV Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>FLASH_CTRL</name>
+      <description>Register map for FLASH_CTRL peripheral</description>
+      <groupName>FLASH_CTRL</groupName>
+      <prependToName>FLASH_CTRL</prependToName>
+      <baseAddress>0x400FD000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <addressBlock>
+        <offset>0x1000</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>FLASH_CTRL</name><value>29</value></interrupt>
+      <registers>
+        <register>
+          <name>FMA</name>
+          <description>Flash Memory Address</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FMA_OFFSET</name>
+              <description>Address Offset</description>
+              <bitRange>[17:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FMD</name>
+          <description>Flash Memory Data</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FMD_DATA</name>
+              <description>Data Value</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FMC</name>
+          <description>Flash Memory Control</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FMC_WRITE</name>
+              <description>Write a Word into Flash Memory</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FMC_ERASE</name>
+              <description>Erase a Page of Flash Memory</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FMC_MERASE</name>
+              <description>Mass Erase Flash Memory</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FMC_COMT</name>
+              <description>Commit Register Value</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FMC_WRKEY</name>
+              <description>FLASH write key</description>
+              <bitRange>[31:17]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCRIS</name>
+          <description>Flash Controller Raw Interrupt Status</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FCRIS_ARIS</name>
+              <description>Access Raw Interrupt Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCRIS_PRIS</name>
+              <description>Programming Raw Interrupt Status</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCRIS_ERIS</name>
+              <description>EEPROM Raw Interrupt Status</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCRIS_VOLTRIS</name>
+              <description>VOLTSTAT Raw Interrupt Status</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCRIS_INVDRIS</name>
+              <description>Invalid Data Raw Interrupt Status</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCRIS_ERRIS</name>
+              <description>ERVER Raw Interrupt Status</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCRIS_PROGRIS</name>
+              <description>PROGVER Raw Interrupt Status</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCIM</name>
+          <description>Flash Controller Interrupt Mask</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FCIM_AMASK</name>
+              <description>Access Interrupt Mask</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCIM_PMASK</name>
+              <description>Programming Interrupt Mask</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCIM_EMASK</name>
+              <description>EEPROM Interrupt Mask</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCIM_VOLTMASK</name>
+              <description>VOLT Interrupt Mask</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCIM_INVDMASK</name>
+              <description>Invalid Data Interrupt Mask</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCIM_ERMASK</name>
+              <description>ERVER Interrupt Mask</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCIM_PROGMASK</name>
+              <description>PROGVER Interrupt Mask</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCMISC</name>
+          <description>Flash Controller Masked Interrupt Status and Clear</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FCMISC_AMISC</name>
+              <description>Access Masked Interrupt Status and Clear</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCMISC_PMISC</name>
+              <description>Programming Masked Interrupt Status and Clear</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCMISC_EMISC</name>
+              <description>EEPROM Masked Interrupt Status and Clear</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCMISC_VOLTMISC</name>
+              <description>VOLT Masked Interrupt Status and Clear</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCMISC_INVDMISC</name>
+              <description>Invalid Data Masked Interrupt Status and Clear</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCMISC_ERMISC</name>
+              <description>ERVER Masked Interrupt Status and Clear</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_FCMISC_PROGMISC</name>
+              <description>PROGVER Masked Interrupt Status and Clear</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FMC2</name>
+          <description>Flash Memory Control 2</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FMC2_WRBUF</name>
+              <description>Buffered Flash Memory Write</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FWBVAL</name>
+          <description>Flash Write Buffer Valid</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FWBVAL_FWB</name>
+              <description>Flash Memory Write Buffer</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FWBN</name>
+          <description>Flash Write Buffer n</description>
+          <addressOffset>0x00000100</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FWBN_DATA</name>
+              <description>Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSIZE</name>
+          <description>Flash Size</description>
+          <addressOffset>0x00000FC0</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_FSIZE_SIZE</name>
+              <description>Flash Size</description>
+              <bitRange>[15:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_8KB</name>
+                  <description>8 KB of Flash</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_16KB</name>
+                  <description>16 KB of Flash</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_32KB</name>
+                  <description>32 KB of Flash</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_64KB</name>
+                  <description>64 KB of Flash</description>
+                  <value>0x1f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_96KB</name>
+                  <description>96 KB of Flash</description>
+                  <value>0x2f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_128KB</name>
+                  <description>128 KB of Flash</description>
+                  <value>0x3f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_192KB</name>
+                  <description>192 KB of Flash</description>
+                  <value>0x5f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_FSIZE_SIZE_256KB</name>
+                  <description>256 KB of Flash</description>
+                  <value>0x7f</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SSIZE</name>
+          <description>SRAM Size</description>
+          <addressOffset>0x00000FC4</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_SSIZE_SIZE</name>
+              <description>SRAM Size</description>
+              <bitRange>[15:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_2KB</name>
+                  <description>2 KB of SRAM</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_4KB</name>
+                  <description>4 KB of SRAM</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_6KB</name>
+                  <description>6 KB of SRAM</description>
+                  <value>0x17</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_8KB</name>
+                  <description>8 KB of SRAM</description>
+                  <value>0x1f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_12KB</name>
+                  <description>12 KB of SRAM</description>
+                  <value>0x2f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_16KB</name>
+                  <description>16 KB of SRAM</description>
+                  <value>0x3f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_20KB</name>
+                  <description>20 KB of SRAM</description>
+                  <value>0x4f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_24KB</name>
+                  <description>24 KB of SRAM</description>
+                  <value>0x5f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_SSIZE_SIZE_32KB</name>
+                  <description>32 KB of SRAM</description>
+                  <value>0x7f</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ROMSWMAP</name>
+          <description>ROM Software Map</description>
+          <addressOffset>0x00000FCC</addressOffset>
+        </register>
+        <register>
+          <name>ROMSWMAP</name>
+          <description>ROM Software Map</description>
+          <alternateGroup>FLASH_CTRL_ALT</alternateGroup>
+          <addressOffset>0x00000FCC</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_ROMSWMAP_SAFERTOS</name>
+              <description>SafeRTOS Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RMCTL</name>
+          <description>ROM Control</description>
+          <addressOffset>0x000010F0</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_RMCTL_BA</name>
+              <description>Boot Alias</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BOOTCFG</name>
+          <description>Boot Configuration</description>
+          <addressOffset>0x000011D0</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_BOOTCFG_DBG0</name>
+              <description>Debug Control 0</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_BOOTCFG_DBG1</name>
+              <description>Debug Control 1</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_BOOTCFG_KEY</name>
+              <description>KEY Select</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_BOOTCFG_EN</name>
+              <description>Boot GPIO Enable</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_BOOTCFG_POL</name>
+              <description>Boot GPIO Polarity</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>FLASH_BOOTCFG_PIN</name>
+              <description>Boot GPIO Pin</description>
+              <bitRange>[12:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_0</name>
+                  <description>Pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_1</name>
+                  <description>Pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_2</name>
+                  <description>Pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_3</name>
+                  <description>Pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_4</name>
+                  <description>Pin 4</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_5</name>
+                  <description>Pin 5</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_6</name>
+                  <description>Pin 6</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PIN_7</name>
+                  <description>Pin 7</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FLASH_BOOTCFG_PORT</name>
+              <description>Boot GPIO Port</description>
+              <bitRange>[15:13]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_A</name>
+                  <description>Port A</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_B</name>
+                  <description>Port B</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_C</name>
+                  <description>Port C</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_D</name>
+                  <description>Port D</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_E</name>
+                  <description>Port E</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_F</name>
+                  <description>Port F</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_G</name>
+                  <description>Port G</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FLASH_BOOTCFG_PORT_H</name>
+                  <description>Port H</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FLASH_BOOTCFG_NW</name>
+              <description>Not Written</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USERREG0</name>
+          <description>User Register 0</description>
+          <addressOffset>0x000011E0</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_USERREG0_DATA</name>
+              <description>User Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USERREG1</name>
+          <description>User Register 1</description>
+          <addressOffset>0x000011E4</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_USERREG1_DATA</name>
+              <description>User Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USERREG2</name>
+          <description>User Register 2</description>
+          <addressOffset>0x000011E8</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_USERREG2_DATA</name>
+              <description>User Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USERREG3</name>
+          <description>User Register 3</description>
+          <addressOffset>0x000011EC</addressOffset>
+          <fields>
+            <field>
+              <name>FLASH_USERREG3_DATA</name>
+              <description>User Data</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FMPRE0</name>
+          <description>Flash Memory Protection Read Enable 0</description>
+          <addressOffset>0x00001200</addressOffset>
+        </register>
+        <register>
+          <name>FMPRE1</name>
+          <description>Flash Memory Protection Read Enable 1</description>
+          <addressOffset>0x00001204</addressOffset>
+        </register>
+        <register>
+          <name>FMPRE2</name>
+          <description>Flash Memory Protection Read Enable 2</description>
+          <addressOffset>0x00001208</addressOffset>
+        </register>
+        <register>
+          <name>FMPRE3</name>
+          <description>Flash Memory Protection Read Enable 3</description>
+          <addressOffset>0x0000120C</addressOffset>
+        </register>
+        <register>
+          <name>FMPPE0</name>
+          <description>Flash Memory Protection Program Enable 0</description>
+          <addressOffset>0x00001400</addressOffset>
+        </register>
+        <register>
+          <name>FMPPE1</name>
+          <description>Flash Memory Protection Program Enable 1</description>
+          <addressOffset>0x00001404</addressOffset>
+        </register>
+        <register>
+          <name>FMPPE2</name>
+          <description>Flash Memory Protection Program Enable 2</description>
+          <addressOffset>0x00001408</addressOffset>
+        </register>
+        <register>
+          <name>FMPPE3</name>
+          <description>Flash Memory Protection Program Enable 3</description>
+          <addressOffset>0x0000140C</addressOffset>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SYSCTL</name>
+      <description>Register map for SYSCTL peripheral</description>
+      <groupName>SYSCTL</groupName>
+      <prependToName>SYSCTL</prependToName>
+      <baseAddress>0x400FE000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>SYSCTL</name><value>28</value></interrupt>
+      <registers>
+        <register>
+          <name>DID0</name>
+          <description>Device Identification 0</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DID0_MIN</name>
+              <description>Minor Revision</description>
+              <bitRange>[7:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_MIN_0</name>
+                  <description>Initial device, or a major revision update</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_MIN_1</name>
+                  <description>First metal layer change</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_MIN_2</name>
+                  <description>Second metal layer change</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DID0_MAJ</name>
+              <description>Major Revision</description>
+              <bitRange>[15:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_MAJ_REVA</name>
+                  <description>Revision A (initial device)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_MAJ_REVB</name>
+                  <description>Revision B (first base layer revision)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_MAJ_REVC</name>
+                  <description>Revision C (second base layer revision)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DID0_CLASS</name>
+              <description>Device Class</description>
+              <bitRange>[23:16]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_CLASS_BLIZZARD</name>
+                  <description>Tiva(TM) C Series Blizzard-class microcontrollers</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DID0_VER</name>
+              <description>DID0 Version</description>
+              <bitRange>[30:28]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID0_VER_1</name>
+                  <description>Second version of the DID0 register format</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DID1</name>
+          <description>Device Identification 1</description>
+          <addressOffset>0x00000004</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DID1_QUAL</name>
+              <description>Qualification Status</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_QUAL_ES</name>
+                  <description>Engineering Sample (unqualified)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_QUAL_PP</name>
+                  <description>Pilot Production (unqualified)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_QUAL_FQ</name>
+                  <description>Fully Qualified</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DID1_ROHS</name>
+              <description>RoHS-Compliance</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DID1_PKG</name>
+              <description>Package Type</description>
+              <bitRange>[4:3]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PKG_SOIC</name>
+                  <description>SOIC package</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PKG_QFP</name>
+                  <description>LQFP package</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PKG_BGA</name>
+                  <description>BGA package</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DID1_TEMP</name>
+              <description>Temperature Range</description>
+              <bitRange>[7:5]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_TEMP_C</name>
+                  <description>Commercial temperature range (0C to 70C)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_TEMP_I</name>
+                  <description>Industrial temperature range (-40C to 85C)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_TEMP_E</name>
+                  <description>Extended temperature range (-40C to 105C)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DID1_PINCNT</name>
+              <description>Package Pin Count</description>
+              <bitRange>[15:13]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PINCNT_28</name>
+                  <description>28-pin package</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PINCNT_48</name>
+                  <description>48-pin package</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PINCNT_100</name>
+                  <description>100-pin package</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PINCNT_64</name>
+                  <description>64-pin package</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PINCNT_144</name>
+                  <description>144-pin package</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DID1_PINCNT_157</name>
+                  <description>157-pin package</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DID1_PRTNO</name>
+              <description>Part Number</description>
+              <bitRange>[23:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DID1_FAM</name>
+              <description>Family</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DID1_VER</name>
+              <description>DID1 Version</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC0</name>
+          <description>Device Capabilities 0</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC0_FLASHSZ</name>
+              <description>Flash Size</description>
+              <bitRange>[15:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_8KB</name>
+                  <description>8 KB of Flash</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_16KB</name>
+                  <description>16 KB of Flash</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_32KB</name>
+                  <description>32 KB of Flash</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_64KB</name>
+                  <description>64 KB of Flash</description>
+                  <value>0x1f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_96KB</name>
+                  <description>96 KB of Flash</description>
+                  <value>0x2f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_128K</name>
+                  <description>128 KB of Flash</description>
+                  <value>0x3f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_192K</name>
+                  <description>192 KB of Flash</description>
+                  <value>0x5f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_FLASHSZ_256K</name>
+                  <description>256 KB of Flash</description>
+                  <value>0x7f</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DC0_SRAMSZ</name>
+              <description>SRAM Size</description>
+              <bitRange>[31:16]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_2KB</name>
+                  <description>2 KB of SRAM</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_4KB</name>
+                  <description>4 KB of SRAM</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_6KB</name>
+                  <description>6 KB of SRAM</description>
+                  <value>0x17</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_8KB</name>
+                  <description>8 KB of SRAM</description>
+                  <value>0x1f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_12KB</name>
+                  <description>12 KB of SRAM</description>
+                  <value>0x2f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_16KB</name>
+                  <description>16 KB of SRAM</description>
+                  <value>0x3f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_20KB</name>
+                  <description>20 KB of SRAM</description>
+                  <value>0x4f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_24KB</name>
+                  <description>24 KB of SRAM</description>
+                  <value>0x5f</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC0_SRAMSZ_32KB</name>
+                  <description>32 KB of SRAM</description>
+                  <value>0x7f</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC1</name>
+          <description>Device Capabilities 1</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC1_JTAG</name>
+              <description>JTAG Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_SWD</name>
+              <description>SWD Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_SWO</name>
+              <description>SWO Trace Port Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_WDT0</name>
+              <description>Watchdog Timer 0 Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_PLL</name>
+              <description>PLL Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_TEMP</name>
+              <description>Temp Sensor Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_HIB</name>
+              <description>Hibernation Module Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_MPU</name>
+              <description>MPU Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_ADC0SPD</name>
+              <description>Max ADC0 Speed</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC0SPD_125K</name>
+                  <description>125K samples/second</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC0SPD_250K</name>
+                  <description>250K samples/second</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC0SPD_500K</name>
+                  <description>500K samples/second</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC0SPD_1M</name>
+                  <description>1M samples/second</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_ADC1SPD</name>
+              <description>Max ADC1 Speed</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC1SPD_125K</name>
+                  <description>125K samples/second</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC1SPD_250K</name>
+                  <description>250K samples/second</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC1SPD_500K</name>
+                  <description>500K samples/second</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_ADC1SPD_1M</name>
+                  <description>1M samples/second</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_MINSYSDIV</name>
+              <description>System Clock Divider</description>
+              <bitRange>[15:12]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_MINSYSDIV_100</name>
+                  <description>Divide VCO (400MHZ) by 5 minimum</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_MINSYSDIV_66</name>
+                  <description>Divide VCO (400MHZ) by 2*2 + 2 = 6 minimum</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_MINSYSDIV_50</name>
+                  <description>Specifies a 50-MHz CPU clock with a PLL divider of 4</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_MINSYSDIV_40</name>
+                  <description>Specifies a 40-MHz CPU clock with a PLL divider of 5</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_MINSYSDIV_25</name>
+                  <description>Specifies a 25-MHz clock with a PLL divider of 8</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC1_MINSYSDIV_20</name>
+                  <description>Specifies a 20-MHz clock with a PLL divider of 10</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_ADC0</name>
+              <description>ADC Module 0 Present</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_ADC1</name>
+              <description>ADC Module 1 Present</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_PWM0</name>
+              <description>PWM Module 0 Present</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_PWM1</name>
+              <description>PWM Module 1 Present</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_CAN0</name>
+              <description>CAN Module 0 Present</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_CAN1</name>
+              <description>CAN Module 1 Present</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC1_WDT1</name>
+              <description>Watchdog Timer1 Present</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC2</name>
+          <description>Device Capabilities 2</description>
+          <addressOffset>0x00000014</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC2_UART0</name>
+              <description>UART Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_UART1</name>
+              <description>UART Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_UART2</name>
+              <description>UART Module 2 Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_SSI0</name>
+              <description>SSI Module 0 Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_SSI1</name>
+              <description>SSI Module 1 Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_QEI0</name>
+              <description>QEI Module 0 Present</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_QEI1</name>
+              <description>QEI Module 1 Present</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_I2C0</name>
+              <description>I2C Module 0 Present</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_I2C0HS</name>
+              <description>I2C Module 0 Speed</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_I2C1</name>
+              <description>I2C Module 1 Present</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_I2C1HS</name>
+              <description>I2C Module 1 Speed</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_TIMER0</name>
+              <description>Timer Module 0 Present</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_TIMER1</name>
+              <description>Timer Module 1 Present</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_TIMER2</name>
+              <description>Timer Module 2 Present</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_TIMER3</name>
+              <description>Timer Module 3 Present</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_COMP0</name>
+              <description>Analog Comparator 0 Present</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_COMP1</name>
+              <description>Analog Comparator 1 Present</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_COMP2</name>
+              <description>Analog Comparator 2 Present</description>
+              <bitRange>[26:26]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_I2S0</name>
+              <description>I2S Module 0 Present</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC2_EPI0</name>
+              <description>EPI Module 0 Present</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC3</name>
+          <description>Device Capabilities 3</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC3_PWM0</name>
+              <description>PWM0 Pin Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_PWM1</name>
+              <description>PWM1 Pin Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_PWM2</name>
+              <description>PWM2 Pin Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_PWM3</name>
+              <description>PWM3 Pin Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_PWM4</name>
+              <description>PWM4 Pin Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_PWM5</name>
+              <description>PWM5 Pin Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C0MINUS</name>
+              <description>C0- Pin Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C0PLUS</name>
+              <description>C0+ Pin Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C0O</name>
+              <description>C0o Pin Present</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C1MINUS</name>
+              <description>C1- Pin Present</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C1PLUS</name>
+              <description>C1+ Pin Present</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C1O</name>
+              <description>C1o Pin Present</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C2MINUS</name>
+              <description>C2- Pin Present</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C2PLUS</name>
+              <description>C2+ Pin Present</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_C2O</name>
+              <description>C2o Pin Present</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_PWMFAULT</name>
+              <description>PWM Fault Pin Present</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN0</name>
+              <description>ADC Module 0 AIN0 Pin Present</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN1</name>
+              <description>ADC Module 0 AIN1 Pin Present</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN2</name>
+              <description>ADC Module 0 AIN2 Pin Present</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN3</name>
+              <description>ADC Module 0 AIN3 Pin Present</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN4</name>
+              <description>ADC Module 0 AIN4 Pin Present</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN5</name>
+              <description>ADC Module 0 AIN5 Pin Present</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN6</name>
+              <description>ADC Module 0 AIN6 Pin Present</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_ADC0AIN7</name>
+              <description>ADC Module 0 AIN7 Pin Present</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_CCP0</name>
+              <description>CCP0 Pin Present</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_CCP1</name>
+              <description>CCP1 Pin Present</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_CCP2</name>
+              <description>CCP2 Pin Present</description>
+              <bitRange>[26:26]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_CCP3</name>
+              <description>CCP3 Pin Present</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_CCP4</name>
+              <description>CCP4 Pin Present</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_CCP5</name>
+              <description>CCP5 Pin Present</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC3_32KHZ</name>
+              <description>32KHz Input Clock Available</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC4</name>
+          <description>Device Capabilities 4</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC4_GPIOA</name>
+              <description>GPIO Port A Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOB</name>
+              <description>GPIO Port B Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOC</name>
+              <description>GPIO Port C Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOD</name>
+              <description>GPIO Port D Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOE</name>
+              <description>GPIO Port E Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOF</name>
+              <description>GPIO Port F Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOG</name>
+              <description>GPIO Port G Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOH</name>
+              <description>GPIO Port H Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_GPIOJ</name>
+              <description>GPIO Port J Present</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_ROM</name>
+              <description>Internal Code ROM Present</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_UDMA</name>
+              <description>Micro-DMA Module Present</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_CCP6</name>
+              <description>CCP6 Pin Present</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_CCP7</name>
+              <description>CCP7 Pin Present</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_PICAL</name>
+              <description>PIOSC Calibrate</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_E1588</name>
+              <description>1588 Capable</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_EMAC0</name>
+              <description>Ethernet MAC Layer 0 Present</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC4_EPHY0</name>
+              <description>Ethernet PHY Layer 0 Present</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC5</name>
+          <description>Device Capabilities 5</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC5_PWM0</name>
+              <description>PWM0 Pin Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWM1</name>
+              <description>PWM1 Pin Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWM2</name>
+              <description>PWM2 Pin Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWM3</name>
+              <description>PWM3 Pin Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWM4</name>
+              <description>PWM4 Pin Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWM5</name>
+              <description>PWM5 Pin Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWM6</name>
+              <description>PWM6 Pin Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWM7</name>
+              <description>PWM7 Pin Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWMESYNC</name>
+              <description>PWM Extended SYNC Active</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWMEFLT</name>
+              <description>PWM Extended Fault Active</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWMFAULT0</name>
+              <description>PWM Fault 0 Pin Present</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWMFAULT1</name>
+              <description>PWM Fault 1 Pin Present</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWMFAULT2</name>
+              <description>PWM Fault 2 Pin Present</description>
+              <bitRange>[26:26]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC5_PWMFAULT3</name>
+              <description>PWM Fault 3 Pin Present</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC6</name>
+          <description>Device Capabilities 6</description>
+          <addressOffset>0x00000024</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC6_USB0</name>
+              <description>USB Module 0 Present</description>
+              <bitRange>[1:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DC6_USB0_DEV</name>
+                  <description>USB0 is Device Only</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC6_USB0_HOSTDEV</name>
+                  <description>USB is Device or Host</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DC6_USB0_OTG</name>
+                  <description>USB0 is OTG</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DC6_USB0PHY</name>
+              <description>USB Module 0 PHY Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC7</name>
+          <description>Device Capabilities 7</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC7_DMACH0</name>
+              <description>USB_EP1_RX / UART2_RX</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH1</name>
+              <description>USB_EP1_TX / UART2_TX</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH2</name>
+              <description>USB_EP2_RX / Timer3A</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH3</name>
+              <description>USB_EP2_TX / Timer3B</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH4</name>
+              <description>USB_EP3_RX / Timer2A</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH5</name>
+              <description>USB_EP3_TX / Timer2B</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH6</name>
+              <description>ETH_RX / Timer2A</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH7</name>
+              <description>ETH_TX / Timer2B</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH8</name>
+              <description>UART0_RX / UART1_RX</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH9</name>
+              <description>UART0_TX / UART1_TX</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH10</name>
+              <description>SSI0_RX / SSI1_RX</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH11</name>
+              <description>SSI0_TX / SSI1_TX</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH12</name>
+              <description>CAN0_RX / UART2_RX</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH13</name>
+              <description>CAN0_TX / UART2_TX</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH14</name>
+              <description>ADC0_SS0 / Timer2A</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH15</name>
+              <description>ADC0_SS1 / Timer2B</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH16</name>
+              <description>ADC0_SS2</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH17</name>
+              <description>ADC0_SS3</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH18</name>
+              <description>Timer0A / Timer1A</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH19</name>
+              <description>Timer0B / Timer1B</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH20</name>
+              <description>Timer1A / EPI0_NBRFIFO</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH21</name>
+              <description>Timer1B / EPI0_WFIFO</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH22</name>
+              <description>UART1_RX / CAN2_RX</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH23</name>
+              <description>UART1_TX / CAN2_TX</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH24</name>
+              <description>SSI1_RX / ADC1_SS0</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH25</name>
+              <description>SSI1_TX / ADC1_SS1</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH26</name>
+              <description>CAN1_RX / ADC1_SS2</description>
+              <bitRange>[26:26]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH27</name>
+              <description>CAN1_TX / ADC1_SS3</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH28</name>
+              <description>I2S0_RX / CAN1_RX</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH29</name>
+              <description>I2S0_TX / CAN1_TX</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC7_DMACH30</name>
+              <description>SW</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC8</name>
+          <description>Device Capabilities 8 ADC Channels</description>
+          <addressOffset>0x0000002C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN0</name>
+              <description>ADC Module 0 AIN0 Pin Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN1</name>
+              <description>ADC Module 0 AIN1 Pin Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN2</name>
+              <description>ADC Module 0 AIN2 Pin Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN3</name>
+              <description>ADC Module 0 AIN3 Pin Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN4</name>
+              <description>ADC Module 0 AIN4 Pin Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN5</name>
+              <description>ADC Module 0 AIN5 Pin Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN6</name>
+              <description>ADC Module 0 AIN6 Pin Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN7</name>
+              <description>ADC Module 0 AIN7 Pin Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN8</name>
+              <description>ADC Module 0 AIN8 Pin Present</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN9</name>
+              <description>ADC Module 0 AIN9 Pin Present</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN10</name>
+              <description>ADC Module 0 AIN10 Pin Present</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN11</name>
+              <description>ADC Module 0 AIN11 Pin Present</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN12</name>
+              <description>ADC Module 0 AIN12 Pin Present</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN13</name>
+              <description>ADC Module 0 AIN13 Pin Present</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN14</name>
+              <description>ADC Module 0 AIN14 Pin Present</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC0AIN15</name>
+              <description>ADC Module 0 AIN15 Pin Present</description>
+              <bitRange>[15:15]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN0</name>
+              <description>ADC Module 1 AIN0 Pin Present</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN1</name>
+              <description>ADC Module 1 AIN1 Pin Present</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN2</name>
+              <description>ADC Module 1 AIN2 Pin Present</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN3</name>
+              <description>ADC Module 1 AIN3 Pin Present</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN4</name>
+              <description>ADC Module 1 AIN4 Pin Present</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN5</name>
+              <description>ADC Module 1 AIN5 Pin Present</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN6</name>
+              <description>ADC Module 1 AIN6 Pin Present</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN7</name>
+              <description>ADC Module 1 AIN7 Pin Present</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN8</name>
+              <description>ADC Module 1 AIN8 Pin Present</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN9</name>
+              <description>ADC Module 1 AIN9 Pin Present</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN10</name>
+              <description>ADC Module 1 AIN10 Pin Present</description>
+              <bitRange>[26:26]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN11</name>
+              <description>ADC Module 1 AIN11 Pin Present</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN12</name>
+              <description>ADC Module 1 AIN12 Pin Present</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN13</name>
+              <description>ADC Module 1 AIN13 Pin Present</description>
+              <bitRange>[29:29]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN14</name>
+              <description>ADC Module 1 AIN14 Pin Present</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC8_ADC1AIN15</name>
+              <description>ADC Module 1 AIN15 Pin Present</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PBORCTL</name>
+          <description>Brown-Out Reset Control</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PBORCTL_BOR1</name>
+              <description>VDD under BOR1 Event Action</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PBORCTL_BOR0</name>
+              <description>VDD under BOR0 Event Action</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRCR0</name>
+          <description>Software Reset Control 0</description>
+          <addressOffset>0x00000040</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRCR0_WDT0</name>
+              <description>WDT0 Reset Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR0_HIB</name>
+              <description>HIB Reset Control</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR0_ADC0</name>
+              <description>ADC0 Reset Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR0_ADC1</name>
+              <description>ADC1 Reset Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR0_PWM0</name>
+              <description>PWM Reset Control</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR0_CAN0</name>
+              <description>CAN0 Reset Control</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR0_CAN1</name>
+              <description>CAN1 Reset Control</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR0_WDT1</name>
+              <description>WDT1 Reset Control</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRCR1</name>
+          <description>Software Reset Control 1</description>
+          <addressOffset>0x00000044</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRCR1_UART0</name>
+              <description>UART0 Reset Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_UART1</name>
+              <description>UART1 Reset Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_UART2</name>
+              <description>UART2 Reset Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_SSI0</name>
+              <description>SSI0 Reset Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_SSI1</name>
+              <description>SSI1 Reset Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_QEI0</name>
+              <description>QEI0 Reset Control</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_QEI1</name>
+              <description>QEI1 Reset Control</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_I2C0</name>
+              <description>I2C0 Reset Control</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_I2C1</name>
+              <description>I2C1 Reset Control</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_TIMER0</name>
+              <description>Timer 0 Reset Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_TIMER1</name>
+              <description>Timer 1 Reset Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_TIMER2</name>
+              <description>Timer 2 Reset Control</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_TIMER3</name>
+              <description>Timer 3 Reset Control</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_COMP0</name>
+              <description>Analog Comp 0 Reset Control</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR1_COMP1</name>
+              <description>Analog Comp 1 Reset Control</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRCR2</name>
+          <description>Software Reset Control 2</description>
+          <addressOffset>0x00000048</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRCR2_GPIOA</name>
+              <description>Port A Reset Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR2_GPIOB</name>
+              <description>Port B Reset Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR2_GPIOC</name>
+              <description>Port C Reset Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR2_GPIOD</name>
+              <description>Port D Reset Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR2_GPIOE</name>
+              <description>Port E Reset Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR2_GPIOF</name>
+              <description>Port F Reset Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR2_UDMA</name>
+              <description>Micro-DMA Reset Control</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCR2_USB0</name>
+              <description>USB0 Reset Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RIS</name>
+          <description>Raw Interrupt Status</description>
+          <addressOffset>0x00000050</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RIS_MOFRIS</name>
+              <description>Main Oscillator Fault Raw Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RIS_PLLLRIS</name>
+              <description>PLL Lock Raw Interrupt Status</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RIS_USBPLLLRIS</name>
+              <description>USB PLL Lock Raw Interrupt Status</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RIS_MOSCPUPRIS</name>
+              <description>MOSC Power Up Raw Interrupt Status</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RIS_VDDARIS</name>
+              <description>VDDA Power OK Event Raw Interrupt Status</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IMC</name>
+          <description>Interrupt Mask Control</description>
+          <addressOffset>0x00000054</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_IMC_MOFIM</name>
+              <description>Main Oscillator Fault Interrupt Mask</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_IMC_PLLLIM</name>
+              <description>PLL Lock Interrupt Mask</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_IMC_USBPLLLIM</name>
+              <description>USB PLL Lock Interrupt Mask</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_IMC_MOSCPUPIM</name>
+              <description>MOSC Power Up Interrupt Mask</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_IMC_VDDAIM</name>
+              <description>VDDA Power OK Interrupt Mask</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MISC</name>
+          <description>Masked Interrupt Status and Clear</description>
+          <addressOffset>0x00000058</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_MISC_MOFMIS</name>
+              <description>Main Oscillator Fault Masked Interrupt Status</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_MISC_PLLLMIS</name>
+              <description>PLL Lock Masked Interrupt Status</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_MISC_USBPLLLMIS</name>
+              <description>USB PLL Lock Masked Interrupt Status</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_MISC_MOSCPUPMIS</name>
+              <description>MOSC Power Up Masked Interrupt Status</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_MISC_VDDAMIS</name>
+              <description>VDDA Power OK Masked Interrupt Status</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RESC</name>
+          <description>Reset Cause</description>
+          <addressOffset>0x0000005C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RESC_EXT</name>
+              <description>External Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RESC_POR</name>
+              <description>Power-On Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RESC_BOR</name>
+              <description>Brown-Out Reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RESC_WDT0</name>
+              <description>Watchdog Timer 0 Reset</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RESC_SW</name>
+              <description>Software Reset</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RESC_WDT1</name>
+              <description>Watchdog Timer 1 Reset</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RESC_MOSCFAIL</name>
+              <description>MOSC Failure Reset</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCC</name>
+          <description>Run-Mode Clock Configuration</description>
+          <addressOffset>0x00000060</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCC_MOSCDIS</name>
+              <description>Main Oscillator Disable</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_OSCSRC</name>
+              <description>Oscillator Source</description>
+              <bitRange>[5:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_OSCSRC_MAIN</name>
+                  <description>MOSC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_OSCSRC_INT</name>
+                  <description>IOSC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_OSCSRC_INT4</name>
+                  <description>IOSC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_OSCSRC_30</name>
+                  <description>30 kHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_XTAL</name>
+              <description>Crystal Value</description>
+              <bitRange>[10:6]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_4MHZ</name>
+                  <description>4 MHz</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_4_09MHZ</name>
+                  <description>4.096 MHz</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_4_91MHZ</name>
+                  <description>4.9152 MHz</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_5MHZ</name>
+                  <description>5 MHz</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_5_12MHZ</name>
+                  <description>5.12 MHz</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_6MHZ</name>
+                  <description>6 MHz</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_6_14MHZ</name>
+                  <description>6.144 MHz</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_7_37MHZ</name>
+                  <description>7.3728 MHz</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_8MHZ</name>
+                  <description>8 MHz</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_8_19MHZ</name>
+                  <description>8.192 MHz</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_10MHZ</name>
+                  <description>10 MHz</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_12MHZ</name>
+                  <description>12 MHz</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_12_2MHZ</name>
+                  <description>12.288 MHz</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_13_5MHZ</name>
+                  <description>13.56 MHz</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_14_3MHZ</name>
+                  <description>14.31818 MHz</description>
+                  <value>0x14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_16MHZ</name>
+                  <description>16 MHz</description>
+                  <value>0x15</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_16_3MHZ</name>
+                  <description>16.384 MHz</description>
+                  <value>0x16</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_18MHZ</name>
+                  <description>18.0 MHz</description>
+                  <value>0x17</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_20MHZ</name>
+                  <description>20.0 MHz</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_24MHZ</name>
+                  <description>24.0 MHz</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_XTAL_25MHZ</name>
+                  <description>25.0 MHz</description>
+                  <value>0x1a</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_BYPASS</name>
+              <description>PLL Bypass</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_PWRDN</name>
+              <description>PLL Power Down</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_PWMDIV</name>
+              <description>PWM Unit Clock Divisor</description>
+              <bitRange>[19:17]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_PWMDIV_2</name>
+                  <description>PWM clock /2</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_PWMDIV_4</name>
+                  <description>PWM clock /4</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_PWMDIV_8</name>
+                  <description>PWM clock /8</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_PWMDIV_16</name>
+                  <description>PWM clock /16</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_PWMDIV_32</name>
+                  <description>PWM clock /32</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC_PWMDIV_64</name>
+                  <description>PWM clock /64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_USEPWMDIV</name>
+              <description>Enable PWM Clock Divisor</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_USESYSDIV</name>
+              <description>Enable System Clock Divider</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_SYSDIV</name>
+              <description>System Clock Divisor</description>
+              <bitRange>[26:23]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC_ACG</name>
+              <description>Auto Clock Gating</description>
+              <bitRange>[27:27]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPIOHBCTL</name>
+          <description>GPIO High-Performance Bus Control</description>
+          <addressOffset>0x0000006C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_GPIOHBCTL_PORTA</name>
+              <description>Port A Advanced High-Performance Bus</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_GPIOHBCTL_PORTB</name>
+              <description>Port B Advanced High-Performance Bus</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_GPIOHBCTL_PORTC</name>
+              <description>Port C Advanced High-Performance Bus</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_GPIOHBCTL_PORTD</name>
+              <description>Port D Advanced High-Performance Bus</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_GPIOHBCTL_PORTE</name>
+              <description>Port E Advanced High-Performance Bus</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_GPIOHBCTL_PORTF</name>
+              <description>Port F Advanced High-Performance Bus</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCC2</name>
+          <description>Run-Mode Clock Configuration 2</description>
+          <addressOffset>0x00000070</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCC2_OSCSRC2</name>
+              <description>Oscillator Source 2</description>
+              <bitRange>[6:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC2_OSCSRC2_MO</name>
+                  <description>MOSC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC2_OSCSRC2_IO</name>
+                  <description>PIOSC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC2_OSCSRC2_IO4</name>
+                  <description>PIOSC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC2_OSCSRC2_30</name>
+                  <description>30 kHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCC2_OSCSRC2_32</name>
+                  <description>32.768 kHz</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_RCC2_BYPASS2</name>
+              <description>PLL Bypass 2</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC2_PWRDN2</name>
+              <description>Power-Down PLL 2</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC2_USBPWRDN</name>
+              <description>Power-Down USB PLL</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC2_SYSDIV2LSB</name>
+              <description>Additional LSB for SYSDIV2</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC2_SYSDIV2</name>
+              <description>System Clock Divisor 2</description>
+              <bitRange>[28:23]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC2_DIV400</name>
+              <description>Divide PLL as 400 MHz vs. 200 MHz</description>
+              <bitRange>[30:30]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCC2_USERCC2</name>
+              <description>Use RCC2</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MOSCCTL</name>
+          <description>Main Oscillator Control</description>
+          <addressOffset>0x0000007C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_MOSCCTL_CVAL</name>
+              <description>Clock Validation for MOSC</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_MOSCCTL_MOSCIM</name>
+              <description>MOSC Failure Action</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_MOSCCTL_NOXTAL</name>
+              <description>No Crystal Connected</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGC0</name>
+          <description>Run Mode Clock Gating Control Register 0</description>
+          <addressOffset>0x00000100</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGC0_WDT0</name>
+              <description>WDT0 Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_HIB</name>
+              <description>HIB Clock Gating Control</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_ADC0SPD</name>
+              <description>ADC0 Sample Speed</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC0SPD_125K</name>
+                  <description>125K samples/second</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC0SPD_250K</name>
+                  <description>250K samples/second</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC0SPD_500K</name>
+                  <description>500K samples/second</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC0SPD_1M</name>
+                  <description>1M samples/second</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_ADC1SPD</name>
+              <description>ADC1 Sample Speed</description>
+              <bitRange>[11:10]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC1SPD_125K</name>
+                  <description>125K samples/second</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC1SPD_250K</name>
+                  <description>250K samples/second</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC1SPD_500K</name>
+                  <description>500K samples/second</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_RCGC0_ADC1SPD_1M</name>
+                  <description>1M samples/second</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_ADC0</name>
+              <description>ADC0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_ADC1</name>
+              <description>ADC1 Clock Gating Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_PWM0</name>
+              <description>PWM Clock Gating Control</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_CAN0</name>
+              <description>CAN0 Clock Gating Control</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_CAN1</name>
+              <description>CAN1 Clock Gating Control</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC0_WDT1</name>
+              <description>WDT1 Clock Gating Control</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGC1</name>
+          <description>Run Mode Clock Gating Control Register 1</description>
+          <addressOffset>0x00000104</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGC1_UART0</name>
+              <description>UART0 Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_UART1</name>
+              <description>UART1 Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_UART2</name>
+              <description>UART2 Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_SSI0</name>
+              <description>SSI0 Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_SSI1</name>
+              <description>SSI1 Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_QEI0</name>
+              <description>QEI0 Clock Gating Control</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_QEI1</name>
+              <description>QEI1 Clock Gating Control</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_I2C0</name>
+              <description>I2C0 Clock Gating Control</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_I2C1</name>
+              <description>I2C1 Clock Gating Control</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_TIMER0</name>
+              <description>Timer 0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_TIMER1</name>
+              <description>Timer 1 Clock Gating Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_TIMER2</name>
+              <description>Timer 2 Clock Gating Control</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_TIMER3</name>
+              <description>Timer 3 Clock Gating Control</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_COMP0</name>
+              <description>Analog Comparator 0 Clock Gating</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC1_COMP1</name>
+              <description>Analog Comparator 1 Clock Gating</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGC2</name>
+          <description>Run Mode Clock Gating Control Register 2</description>
+          <addressOffset>0x00000108</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGC2_GPIOA</name>
+              <description>Port A Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC2_GPIOB</name>
+              <description>Port B Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC2_GPIOC</name>
+              <description>Port C Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC2_GPIOD</name>
+              <description>Port D Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC2_GPIOE</name>
+              <description>Port E Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC2_GPIOF</name>
+              <description>Port F Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC2_UDMA</name>
+              <description>Micro-DMA Clock Gating Control</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGC2_USB0</name>
+              <description>USB0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGC0</name>
+          <description>Sleep Mode Clock Gating Control Register 0</description>
+          <addressOffset>0x00000110</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGC0_WDT0</name>
+              <description>WDT0 Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC0_HIB</name>
+              <description>HIB Clock Gating Control</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC0_ADC0</name>
+              <description>ADC0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC0_ADC1</name>
+              <description>ADC1 Clock Gating Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC0_PWM0</name>
+              <description>PWM Clock Gating Control</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC0_CAN0</name>
+              <description>CAN0 Clock Gating Control</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC0_CAN1</name>
+              <description>CAN1 Clock Gating Control</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC0_WDT1</name>
+              <description>WDT1 Clock Gating Control</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGC1</name>
+          <description>Sleep Mode Clock Gating Control Register 1</description>
+          <addressOffset>0x00000114</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGC1_UART0</name>
+              <description>UART0 Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_UART1</name>
+              <description>UART1 Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_UART2</name>
+              <description>UART2 Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_SSI0</name>
+              <description>SSI0 Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_SSI1</name>
+              <description>SSI1 Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_QEI0</name>
+              <description>QEI0 Clock Gating Control</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_QEI1</name>
+              <description>QEI1 Clock Gating Control</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_I2C0</name>
+              <description>I2C0 Clock Gating Control</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_I2C1</name>
+              <description>I2C1 Clock Gating Control</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_TIMER0</name>
+              <description>Timer 0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_TIMER1</name>
+              <description>Timer 1 Clock Gating Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_TIMER2</name>
+              <description>Timer 2 Clock Gating Control</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_TIMER3</name>
+              <description>Timer 3 Clock Gating Control</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_COMP0</name>
+              <description>Analog Comparator 0 Clock Gating</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC1_COMP1</name>
+              <description>Analog Comparator 1 Clock Gating</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGC2</name>
+          <description>Sleep Mode Clock Gating Control Register 2</description>
+          <addressOffset>0x00000118</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGC2_GPIOA</name>
+              <description>Port A Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC2_GPIOB</name>
+              <description>Port B Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC2_GPIOC</name>
+              <description>Port C Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC2_GPIOD</name>
+              <description>Port D Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC2_GPIOE</name>
+              <description>Port E Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC2_GPIOF</name>
+              <description>Port F Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC2_UDMA</name>
+              <description>Micro-DMA Clock Gating Control</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGC2_USB0</name>
+              <description>USB0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGC0</name>
+          <description>Deep Sleep Mode Clock Gating Control Register 0</description>
+          <addressOffset>0x00000120</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGC0_WDT0</name>
+              <description>WDT0 Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC0_HIB</name>
+              <description>HIB Clock Gating Control</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC0_ADC0</name>
+              <description>ADC0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC0_ADC1</name>
+              <description>ADC1 Clock Gating Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC0_PWM0</name>
+              <description>PWM Clock Gating Control</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC0_CAN0</name>
+              <description>CAN0 Clock Gating Control</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC0_CAN1</name>
+              <description>CAN1 Clock Gating Control</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC0_WDT1</name>
+              <description>WDT1 Clock Gating Control</description>
+              <bitRange>[28:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGC1</name>
+          <description>Deep-Sleep Mode Clock Gating Control Register 1</description>
+          <addressOffset>0x00000124</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGC1_UART0</name>
+              <description>UART0 Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_UART1</name>
+              <description>UART1 Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_UART2</name>
+              <description>UART2 Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_SSI0</name>
+              <description>SSI0 Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_SSI1</name>
+              <description>SSI1 Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_QEI0</name>
+              <description>QEI0 Clock Gating Control</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_QEI1</name>
+              <description>QEI1 Clock Gating Control</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_I2C0</name>
+              <description>I2C0 Clock Gating Control</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_I2C1</name>
+              <description>I2C1 Clock Gating Control</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_TIMER0</name>
+              <description>Timer 0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_TIMER1</name>
+              <description>Timer 1 Clock Gating Control</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_TIMER2</name>
+              <description>Timer 2 Clock Gating Control</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_TIMER3</name>
+              <description>Timer 3 Clock Gating Control</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_COMP0</name>
+              <description>Analog Comparator 0 Clock Gating</description>
+              <bitRange>[24:24]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC1_COMP1</name>
+              <description>Analog Comparator 1 Clock Gating</description>
+              <bitRange>[25:25]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGC2</name>
+          <description>Deep Sleep Mode Clock Gating Control Register 2</description>
+          <addressOffset>0x00000128</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGC2_GPIOA</name>
+              <description>Port A Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC2_GPIOB</name>
+              <description>Port B Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC2_GPIOC</name>
+              <description>Port C Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC2_GPIOD</name>
+              <description>Port D Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC2_GPIOE</name>
+              <description>Port E Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC2_GPIOF</name>
+              <description>Port F Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC2_UDMA</name>
+              <description>Micro-DMA Clock Gating Control</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGC2_USB0</name>
+              <description>USB0 Clock Gating Control</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DSLPCLKCFG</name>
+          <description>Deep Sleep Clock Configuration</description>
+          <addressOffset>0x00000144</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DSLPCLKCFG_O</name>
+              <description>Clock Source</description>
+              <bitRange>[6:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_DSLPCLKCFG_O_IGN</name>
+                  <description>MOSC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DSLPCLKCFG_O_IO</name>
+                  <description>PIOSC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DSLPCLKCFG_O_30</name>
+                  <description>30 kHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_DSLPCLKCFG_O_32</name>
+                  <description>32.768 kHz</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_DSLPCLKCFG_D</name>
+              <description>Divider Field Override</description>
+              <bitRange>[28:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYSPROP</name>
+          <description>System Properties</description>
+          <addressOffset>0x0000014C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SYSPROP_FPU</name>
+              <description>FPU Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PIOSCCAL</name>
+          <description>Precision Internal Oscillator Calibration</description>
+          <addressOffset>0x00000150</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PIOSCCAL_UT</name>
+              <description>User Trim Value</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PIOSCCAL_UPDATE</name>
+              <description>Update Trim</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PIOSCCAL_CAL</name>
+              <description>Start Calibration</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PIOSCCAL_UTEN</name>
+              <description>Use User Trim Value</description>
+              <bitRange>[31:31]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PIOSCSTAT</name>
+          <description>Precision Internal Oscillator Statistics</description>
+          <addressOffset>0x00000154</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PIOSCSTAT_CT</name>
+              <description>Calibration Trim Value</description>
+              <bitRange>[6:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PIOSCSTAT_CR</name>
+              <description>Calibration Result</description>
+              <bitRange>[9:8]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>SYSCTL_PIOSCSTAT_CRNONE</name>
+                  <description>Calibration has not been attempted</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_PIOSCSTAT_CRPASS</name>
+                  <description>The last calibration operation completed to meet 1% accuracy</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYSCTL_PIOSCSTAT_CRFAIL</name>
+                  <description>The last calibration operation failed to meet 1% accuracy</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SYSCTL_PIOSCSTAT_DT</name>
+              <description>Default Trim Value</description>
+              <bitRange>[22:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PLLFREQ0</name>
+          <description>PLL Frequency 0</description>
+          <addressOffset>0x00000160</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PLLFREQ0_MINT</name>
+              <description>PLL M Integer Value</description>
+              <bitRange>[9:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PLLFREQ0_MFRAC</name>
+              <description>PLL M Fractional Value</description>
+              <bitRange>[19:10]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PLLFREQ1</name>
+          <description>PLL Frequency 1</description>
+          <addressOffset>0x00000164</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PLLFREQ1_N</name>
+              <description>PLL N Value</description>
+              <bitRange>[4:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PLLFREQ1_Q</name>
+              <description>PLL Q Value</description>
+              <bitRange>[12:8]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PLLSTAT</name>
+          <description>PLL Status</description>
+          <addressOffset>0x00000168</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PLLSTAT_LOCK</name>
+              <description>PLL Lock</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DC9</name>
+          <description>Device Capabilities 9 ADC Digital Comparators</description>
+          <addressOffset>0x00000190</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC0</name>
+              <description>ADC0 DC0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC1</name>
+              <description>ADC0 DC1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC2</name>
+              <description>ADC0 DC2 Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC3</name>
+              <description>ADC0 DC3 Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC4</name>
+              <description>ADC0 DC4 Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC5</name>
+              <description>ADC0 DC5 Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC6</name>
+              <description>ADC0 DC6 Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC0DC7</name>
+              <description>ADC0 DC7 Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC0</name>
+              <description>ADC1 DC0 Present</description>
+              <bitRange>[16:16]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC1</name>
+              <description>ADC1 DC1 Present</description>
+              <bitRange>[17:17]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC2</name>
+              <description>ADC1 DC2 Present</description>
+              <bitRange>[18:18]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC3</name>
+              <description>ADC1 DC3 Present</description>
+              <bitRange>[19:19]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC4</name>
+              <description>ADC1 DC4 Present</description>
+              <bitRange>[20:20]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC5</name>
+              <description>ADC1 DC5 Present</description>
+              <bitRange>[21:21]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC6</name>
+              <description>ADC1 DC6 Present</description>
+              <bitRange>[22:22]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DC9_ADC1DC7</name>
+              <description>ADC1 DC7 Present</description>
+              <bitRange>[23:23]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NVMSTAT</name>
+          <description>Non-Volatile Memory Information</description>
+          <addressOffset>0x000001A0</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_NVMSTAT_FWB</name>
+              <description>32 Word Flash Write Buffer Active</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPWD</name>
+          <description>Watchdog Timer Peripheral Present</description>
+          <addressOffset>0x00000300</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPWD_P0</name>
+              <description>Watchdog Timer 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPWD_P1</name>
+              <description>Watchdog Timer 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPTIMER</name>
+          <description>Timer Peripheral Present</description>
+          <addressOffset>0x00000304</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPTIMER_P0</name>
+              <description>Timer 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPTIMER_P1</name>
+              <description>Timer 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPTIMER_P2</name>
+              <description>Timer 2 Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPTIMER_P3</name>
+              <description>Timer 3 Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPTIMER_P4</name>
+              <description>Timer 4 Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPTIMER_P5</name>
+              <description>Timer 5 Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPGPIO</name>
+          <description>General-Purpose Input/Output Peripheral Present</description>
+          <addressOffset>0x00000308</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPGPIO_P0</name>
+              <description>GPIO Port A Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P1</name>
+              <description>GPIO Port B Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P2</name>
+              <description>GPIO Port C Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P3</name>
+              <description>GPIO Port D Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P4</name>
+              <description>GPIO Port E Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P5</name>
+              <description>GPIO Port F Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P6</name>
+              <description>GPIO Port G Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P7</name>
+              <description>GPIO Port H Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P8</name>
+              <description>GPIO Port J Present</description>
+              <bitRange>[8:8]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P9</name>
+              <description>GPIO Port K Present</description>
+              <bitRange>[9:9]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P10</name>
+              <description>GPIO Port L Present</description>
+              <bitRange>[10:10]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P11</name>
+              <description>GPIO Port M Present</description>
+              <bitRange>[11:11]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P12</name>
+              <description>GPIO Port N Present</description>
+              <bitRange>[12:12]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P13</name>
+              <description>GPIO Port P Present</description>
+              <bitRange>[13:13]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPGPIO_P14</name>
+              <description>GPIO Port Q Present</description>
+              <bitRange>[14:14]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPDMA</name>
+          <description>Micro Direct Memory Access Peripheral Present</description>
+          <addressOffset>0x0000030C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPDMA_P0</name>
+              <description>uDMA Module Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPHIB</name>
+          <description>Hibernation Peripheral Present</description>
+          <addressOffset>0x00000314</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPHIB_P0</name>
+              <description>Hibernation Module Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPUART</name>
+          <description>Universal Asynchronous Receiver/Transmitter Peripheral Present</description>
+          <addressOffset>0x00000318</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPUART_P0</name>
+              <description>UART Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPUART_P1</name>
+              <description>UART Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPUART_P2</name>
+              <description>UART Module 2 Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPUART_P3</name>
+              <description>UART Module 3 Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPUART_P4</name>
+              <description>UART Module 4 Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPUART_P5</name>
+              <description>UART Module 5 Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPUART_P6</name>
+              <description>UART Module 6 Present</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPUART_P7</name>
+              <description>UART Module 7 Present</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPSSI</name>
+          <description>Synchronous Serial Interface Peripheral Present</description>
+          <addressOffset>0x0000031C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPSSI_P0</name>
+              <description>SSI Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPSSI_P1</name>
+              <description>SSI Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPSSI_P2</name>
+              <description>SSI Module 2 Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPSSI_P3</name>
+              <description>SSI Module 3 Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPI2C</name>
+          <description>Inter-Integrated Circuit Peripheral Present</description>
+          <addressOffset>0x00000320</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPI2C_P0</name>
+              <description>I2C Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPI2C_P1</name>
+              <description>I2C Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPI2C_P2</name>
+              <description>I2C Module 2 Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPI2C_P3</name>
+              <description>I2C Module 3 Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPI2C_P4</name>
+              <description>I2C Module 4 Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPI2C_P5</name>
+              <description>I2C Module 5 Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPUSB</name>
+          <description>Universal Serial Bus Peripheral Present</description>
+          <addressOffset>0x00000328</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPUSB_P0</name>
+              <description>USB Module Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPCAN</name>
+          <description>Controller Area Network Peripheral Present</description>
+          <addressOffset>0x00000334</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPCAN_P0</name>
+              <description>CAN Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPCAN_P1</name>
+              <description>CAN Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPADC</name>
+          <description>Analog-to-Digital Converter Peripheral Present</description>
+          <addressOffset>0x00000338</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPADC_P0</name>
+              <description>ADC Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPADC_P1</name>
+              <description>ADC Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPACMP</name>
+          <description>Analog Comparator Peripheral Present</description>
+          <addressOffset>0x0000033C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPACMP_P0</name>
+              <description>Analog Comparator Module Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPPWM</name>
+          <description>Pulse Width Modulator Peripheral Present</description>
+          <addressOffset>0x00000340</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPPWM_P0</name>
+              <description>PWM Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPPWM_P1</name>
+              <description>PWM Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPQEI</name>
+          <description>Quadrature Encoder Interface Peripheral Present</description>
+          <addressOffset>0x00000344</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPQEI_P0</name>
+              <description>QEI Module 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPQEI_P1</name>
+              <description>QEI Module 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPEEPROM</name>
+          <description>EEPROM Peripheral Present</description>
+          <addressOffset>0x00000358</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPEEPROM_P0</name>
+              <description>EEPROM Module Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PPWTIMER</name>
+          <description>Wide Timer Peripheral Present</description>
+          <addressOffset>0x0000035C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PPWTIMER_P0</name>
+              <description>Wide Timer 0 Present</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPWTIMER_P1</name>
+              <description>Wide Timer 1 Present</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPWTIMER_P2</name>
+              <description>Wide Timer 2 Present</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPWTIMER_P3</name>
+              <description>Wide Timer 3 Present</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPWTIMER_P4</name>
+              <description>Wide Timer 4 Present</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PPWTIMER_P5</name>
+              <description>Wide Timer 5 Present</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRWD</name>
+          <description>Watchdog Timer Software Reset</description>
+          <addressOffset>0x00000500</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRWD_R0</name>
+              <description>Watchdog Timer 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRWD_R1</name>
+              <description>Watchdog Timer 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRTIMER</name>
+          <description>Timer Software Reset</description>
+          <addressOffset>0x00000504</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRTIMER_R0</name>
+              <description>Timer 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRTIMER_R1</name>
+              <description>Timer 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRTIMER_R2</name>
+              <description>Timer 2 Software Reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRTIMER_R3</name>
+              <description>Timer 3 Software Reset</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRTIMER_R4</name>
+              <description>Timer 4 Software Reset</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRTIMER_R5</name>
+              <description>Timer 5 Software Reset</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRGPIO</name>
+          <description>General-Purpose Input/Output Software Reset</description>
+          <addressOffset>0x00000508</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRGPIO_R0</name>
+              <description>GPIO Port A Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRGPIO_R1</name>
+              <description>GPIO Port B Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRGPIO_R2</name>
+              <description>GPIO Port C Software Reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRGPIO_R3</name>
+              <description>GPIO Port D Software Reset</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRGPIO_R4</name>
+              <description>GPIO Port E Software Reset</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRGPIO_R5</name>
+              <description>GPIO Port F Software Reset</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRDMA</name>
+          <description>Micro Direct Memory Access Software Reset</description>
+          <addressOffset>0x0000050C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRDMA_R0</name>
+              <description>uDMA Module Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRHIB</name>
+          <description>Hibernation Software Reset</description>
+          <addressOffset>0x00000514</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRHIB_R0</name>
+              <description>Hibernation Module Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRUART</name>
+          <description>Universal Asynchronous Receiver/Transmitter Software Reset</description>
+          <addressOffset>0x00000518</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRUART_R0</name>
+              <description>UART Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRUART_R1</name>
+              <description>UART Module 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRUART_R2</name>
+              <description>UART Module 2 Software Reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRUART_R3</name>
+              <description>UART Module 3 Software Reset</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRUART_R4</name>
+              <description>UART Module 4 Software Reset</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRUART_R5</name>
+              <description>UART Module 5 Software Reset</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRUART_R6</name>
+              <description>UART Module 6 Software Reset</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRUART_R7</name>
+              <description>UART Module 7 Software Reset</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRSSI</name>
+          <description>Synchronous Serial Interface Software Reset</description>
+          <addressOffset>0x0000051C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRSSI_R0</name>
+              <description>SSI Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRSSI_R1</name>
+              <description>SSI Module 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRSSI_R2</name>
+              <description>SSI Module 2 Software Reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRSSI_R3</name>
+              <description>SSI Module 3 Software Reset</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRI2C</name>
+          <description>Inter-Integrated Circuit Software Reset</description>
+          <addressOffset>0x00000520</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRI2C_R0</name>
+              <description>I2C Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRI2C_R1</name>
+              <description>I2C Module 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRI2C_R2</name>
+              <description>I2C Module 2 Software Reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRI2C_R3</name>
+              <description>I2C Module 3 Software Reset</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRUSB</name>
+          <description>Universal Serial Bus Software Reset</description>
+          <addressOffset>0x00000528</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRUSB_R0</name>
+              <description>USB Module Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRCAN</name>
+          <description>Controller Area Network Software Reset</description>
+          <addressOffset>0x00000534</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRCAN_R0</name>
+              <description>CAN Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRCAN_R1</name>
+              <description>CAN Module 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRADC</name>
+          <description>Analog-to-Digital Converter Software Reset</description>
+          <addressOffset>0x00000538</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRADC_R0</name>
+              <description>ADC Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRADC_R1</name>
+              <description>ADC Module 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRACMP</name>
+          <description>Analog Comparator Software Reset</description>
+          <addressOffset>0x0000053C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRACMP_R0</name>
+              <description>Analog Comparator Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRPWM</name>
+          <description>Pulse Width Modulator Software Reset</description>
+          <addressOffset>0x00000540</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRPWM_R0</name>
+              <description>PWM Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRPWM_R1</name>
+              <description>PWM Module 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRQEI</name>
+          <description>Quadrature Encoder Interface Software Reset</description>
+          <addressOffset>0x00000544</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRQEI_R0</name>
+              <description>QEI Module 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRQEI_R1</name>
+              <description>QEI Module 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SREEPROM</name>
+          <description>EEPROM Software Reset</description>
+          <addressOffset>0x00000558</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SREEPROM_R0</name>
+              <description>EEPROM Module Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SRWTIMER</name>
+          <description>Wide Timer Software Reset</description>
+          <addressOffset>0x0000055C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SRWTIMER_R0</name>
+              <description>Wide Timer 0 Software Reset</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRWTIMER_R1</name>
+              <description>Wide Timer 1 Software Reset</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRWTIMER_R2</name>
+              <description>Wide Timer 2 Software Reset</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRWTIMER_R3</name>
+              <description>Wide Timer 3 Software Reset</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRWTIMER_R4</name>
+              <description>Wide Timer 4 Software Reset</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SRWTIMER_R5</name>
+              <description>Wide Timer 5 Software Reset</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCWD</name>
+          <description>Watchdog Timer Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000600</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCWD_R0</name>
+              <description>Watchdog Timer 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCWD_R1</name>
+              <description>Watchdog Timer 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCTIMER</name>
+          <description>Timer Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000604</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCTIMER_R0</name>
+              <description>Timer 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCTIMER_R1</name>
+              <description>Timer 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCTIMER_R2</name>
+              <description>Timer 2 Run Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCTIMER_R3</name>
+              <description>Timer 3 Run Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCTIMER_R4</name>
+              <description>Timer 4 Run Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCTIMER_R5</name>
+              <description>Timer 5 Run Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCGPIO</name>
+          <description>General-Purpose Input/Output Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000608</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCGPIO_R0</name>
+              <description>GPIO Port A Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCGPIO_R1</name>
+              <description>GPIO Port B Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCGPIO_R2</name>
+              <description>GPIO Port C Run Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCGPIO_R3</name>
+              <description>GPIO Port D Run Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCGPIO_R4</name>
+              <description>GPIO Port E Run Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCGPIO_R5</name>
+              <description>GPIO Port F Run Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCDMA</name>
+          <description>Micro Direct Memory Access Run Mode Clock Gating Control</description>
+          <addressOffset>0x0000060C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCDMA_R0</name>
+              <description>uDMA Module Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCHIB</name>
+          <description>Hibernation Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000614</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCHIB_R0</name>
+              <description>Hibernation Module Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCUART</name>
+          <description>Universal Asynchronous Receiver/Transmitter Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000618</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCUART_R0</name>
+              <description>UART Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCUART_R1</name>
+              <description>UART Module 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCUART_R2</name>
+              <description>UART Module 2 Run Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCUART_R3</name>
+              <description>UART Module 3 Run Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCUART_R4</name>
+              <description>UART Module 4 Run Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCUART_R5</name>
+              <description>UART Module 5 Run Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCUART_R6</name>
+              <description>UART Module 6 Run Mode Clock Gating Control</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCUART_R7</name>
+              <description>UART Module 7 Run Mode Clock Gating Control</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCSSI</name>
+          <description>Synchronous Serial Interface Run Mode Clock Gating Control</description>
+          <addressOffset>0x0000061C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCSSI_R0</name>
+              <description>SSI Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCSSI_R1</name>
+              <description>SSI Module 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCSSI_R2</name>
+              <description>SSI Module 2 Run Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCSSI_R3</name>
+              <description>SSI Module 3 Run Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCI2C</name>
+          <description>Inter-Integrated Circuit Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000620</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCI2C_R0</name>
+              <description>I2C Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCI2C_R1</name>
+              <description>I2C Module 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCI2C_R2</name>
+              <description>I2C Module 2 Run Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCI2C_R3</name>
+              <description>I2C Module 3 Run Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCUSB</name>
+          <description>Universal Serial Bus Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000628</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCUSB_R0</name>
+              <description>USB Module Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCCAN</name>
+          <description>Controller Area Network Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000634</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCCAN_R0</name>
+              <description>CAN Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCCAN_R1</name>
+              <description>CAN Module 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCADC</name>
+          <description>Analog-to-Digital Converter Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000638</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCADC_R0</name>
+              <description>ADC Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCADC_R1</name>
+              <description>ADC Module 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCACMP</name>
+          <description>Analog Comparator Run Mode Clock Gating Control</description>
+          <addressOffset>0x0000063C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCACMP_R0</name>
+              <description>Analog Comparator Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCPWM</name>
+          <description>Pulse Width Modulator Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000640</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCPWM_R0</name>
+              <description>PWM Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCPWM_R1</name>
+              <description>PWM Module 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCQEI</name>
+          <description>Quadrature Encoder Interface Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000644</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCQEI_R0</name>
+              <description>QEI Module 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCQEI_R1</name>
+              <description>QEI Module 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCEEPROM</name>
+          <description>EEPROM Run Mode Clock Gating Control</description>
+          <addressOffset>0x00000658</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCEEPROM_R0</name>
+              <description>EEPROM Module Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCGCWTIMER</name>
+          <description>Wide Timer Run Mode Clock Gating Control</description>
+          <addressOffset>0x0000065C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_RCGCWTIMER_R0</name>
+              <description>Wide Timer 0 Run Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCWTIMER_R1</name>
+              <description>Wide Timer 1 Run Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCWTIMER_R2</name>
+              <description>Wide Timer 2 Run Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCWTIMER_R3</name>
+              <description>Wide Timer 3 Run Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCWTIMER_R4</name>
+              <description>Wide Timer 4 Run Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_RCGCWTIMER_R5</name>
+              <description>Wide Timer 5 Run Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCWD</name>
+          <description>Watchdog Timer Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000700</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCWD_S0</name>
+              <description>Watchdog Timer 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCWD_S1</name>
+              <description>Watchdog Timer 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCTIMER</name>
+          <description>Timer Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000704</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCTIMER_S0</name>
+              <description>Timer 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCTIMER_S1</name>
+              <description>Timer 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCTIMER_S2</name>
+              <description>Timer 2 Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCTIMER_S3</name>
+              <description>Timer 3 Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCTIMER_S4</name>
+              <description>Timer 4 Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCTIMER_S5</name>
+              <description>Timer 5 Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCGPIO</name>
+          <description>General-Purpose Input/Output Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000708</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCGPIO_S0</name>
+              <description>GPIO Port A Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCGPIO_S1</name>
+              <description>GPIO Port B Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCGPIO_S2</name>
+              <description>GPIO Port C Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCGPIO_S3</name>
+              <description>GPIO Port D Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCGPIO_S4</name>
+              <description>GPIO Port E Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCGPIO_S5</name>
+              <description>GPIO Port F Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCDMA</name>
+          <description>Micro Direct Memory Access Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000070C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCDMA_S0</name>
+              <description>uDMA Module Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCHIB</name>
+          <description>Hibernation Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000714</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCHIB_S0</name>
+              <description>Hibernation Module Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCUART</name>
+          <description>Universal Asynchronous Receiver/Transmitter Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000718</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCUART_S0</name>
+              <description>UART Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCUART_S1</name>
+              <description>UART Module 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCUART_S2</name>
+              <description>UART Module 2 Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCUART_S3</name>
+              <description>UART Module 3 Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCUART_S4</name>
+              <description>UART Module 4 Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCUART_S5</name>
+              <description>UART Module 5 Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCUART_S6</name>
+              <description>UART Module 6 Sleep Mode Clock Gating Control</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCUART_S7</name>
+              <description>UART Module 7 Sleep Mode Clock Gating Control</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCSSI</name>
+          <description>Synchronous Serial Interface Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000071C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCSSI_S0</name>
+              <description>SSI Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCSSI_S1</name>
+              <description>SSI Module 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCSSI_S2</name>
+              <description>SSI Module 2 Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCSSI_S3</name>
+              <description>SSI Module 3 Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCI2C</name>
+          <description>Inter-Integrated Circuit Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000720</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCI2C_S0</name>
+              <description>I2C Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCI2C_S1</name>
+              <description>I2C Module 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCI2C_S2</name>
+              <description>I2C Module 2 Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCI2C_S3</name>
+              <description>I2C Module 3 Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCUSB</name>
+          <description>Universal Serial Bus Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000728</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCUSB_S0</name>
+              <description>USB Module Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCCAN</name>
+          <description>Controller Area Network Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000734</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCCAN_S0</name>
+              <description>CAN Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCCAN_S1</name>
+              <description>CAN Module 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCADC</name>
+          <description>Analog-to-Digital Converter Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000738</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCADC_S0</name>
+              <description>ADC Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCADC_S1</name>
+              <description>ADC Module 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCACMP</name>
+          <description>Analog Comparator Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000073C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCACMP_S0</name>
+              <description>Analog Comparator Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCPWM</name>
+          <description>Pulse Width Modulator Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000740</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCPWM_S0</name>
+              <description>PWM Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCPWM_S1</name>
+              <description>PWM Module 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCQEI</name>
+          <description>Quadrature Encoder Interface Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000744</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCQEI_S0</name>
+              <description>QEI Module 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCQEI_S1</name>
+              <description>QEI Module 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCEEPROM</name>
+          <description>EEPROM Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000758</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCEEPROM_S0</name>
+              <description>EEPROM Module Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SCGCWTIMER</name>
+          <description>Wide Timer Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000075C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_SCGCWTIMER_S0</name>
+              <description>Wide Timer 0 Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCWTIMER_S1</name>
+              <description>Wide Timer 1 Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCWTIMER_S2</name>
+              <description>Wide Timer 2 Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCWTIMER_S3</name>
+              <description>Wide Timer 3 Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCWTIMER_S4</name>
+              <description>Wide Timer 4 Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_SCGCWTIMER_S5</name>
+              <description>Wide Timer 5 Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCWD</name>
+          <description>Watchdog Timer Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000800</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCWD_D0</name>
+              <description>Watchdog Timer 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCWD_D1</name>
+              <description>Watchdog Timer 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCTIMER</name>
+          <description>Timer Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000804</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCTIMER_D0</name>
+              <description>Timer 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCTIMER_D1</name>
+              <description>Timer 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCTIMER_D2</name>
+              <description>Timer 2 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCTIMER_D3</name>
+              <description>Timer 3 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCTIMER_D4</name>
+              <description>Timer 4 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCTIMER_D5</name>
+              <description>Timer 5 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCGPIO</name>
+          <description>General-Purpose Input/Output Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000808</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCGPIO_D0</name>
+              <description>GPIO Port A Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCGPIO_D1</name>
+              <description>GPIO Port B Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCGPIO_D2</name>
+              <description>GPIO Port C Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCGPIO_D3</name>
+              <description>GPIO Port D Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCGPIO_D4</name>
+              <description>GPIO Port E Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCGPIO_D5</name>
+              <description>GPIO Port F Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCDMA</name>
+          <description>Micro Direct Memory Access Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000080C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCDMA_D0</name>
+              <description>uDMA Module Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCHIB</name>
+          <description>Hibernation Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000814</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCHIB_D0</name>
+              <description>Hibernation Module Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCUART</name>
+          <description>Universal Asynchronous Receiver/Transmitter Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000818</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCUART_D0</name>
+              <description>UART Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCUART_D1</name>
+              <description>UART Module 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCUART_D2</name>
+              <description>UART Module 2 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCUART_D3</name>
+              <description>UART Module 3 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCUART_D4</name>
+              <description>UART Module 4 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCUART_D5</name>
+              <description>UART Module 5 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCUART_D6</name>
+              <description>UART Module 6 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCUART_D7</name>
+              <description>UART Module 7 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCSSI</name>
+          <description>Synchronous Serial Interface Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000081C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCSSI_D0</name>
+              <description>SSI Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCSSI_D1</name>
+              <description>SSI Module 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCSSI_D2</name>
+              <description>SSI Module 2 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCSSI_D3</name>
+              <description>SSI Module 3 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCI2C</name>
+          <description>Inter-Integrated Circuit Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000820</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCI2C_D0</name>
+              <description>I2C Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCI2C_D1</name>
+              <description>I2C Module 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCI2C_D2</name>
+              <description>I2C Module 2 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCI2C_D3</name>
+              <description>I2C Module 3 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCUSB</name>
+          <description>Universal Serial Bus Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000828</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCUSB_D0</name>
+              <description>USB Module Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCCAN</name>
+          <description>Controller Area Network Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000834</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCCAN_D0</name>
+              <description>CAN Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCCAN_D1</name>
+              <description>CAN Module 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCADC</name>
+          <description>Analog-to-Digital Converter Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000838</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCADC_D0</name>
+              <description>ADC Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCADC_D1</name>
+              <description>ADC Module 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCACMP</name>
+          <description>Analog Comparator Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000083C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCACMP_D0</name>
+              <description>Analog Comparator Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCPWM</name>
+          <description>Pulse Width Modulator Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000840</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCPWM_D0</name>
+              <description>PWM Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCPWM_D1</name>
+              <description>PWM Module 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCQEI</name>
+          <description>Quadrature Encoder Interface Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000844</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCQEI_D0</name>
+              <description>QEI Module 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCQEI_D1</name>
+              <description>QEI Module 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCEEPROM</name>
+          <description>EEPROM Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x00000858</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCEEPROM_D0</name>
+              <description>EEPROM Module Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DCGCWTIMER</name>
+          <description>Wide Timer Deep-Sleep Mode Clock Gating Control</description>
+          <addressOffset>0x0000085C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_DCGCWTIMER_D0</name>
+              <description>Wide Timer 0 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCWTIMER_D1</name>
+              <description>Wide Timer 1 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCWTIMER_D2</name>
+              <description>Wide Timer 2 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCWTIMER_D3</name>
+              <description>Wide Timer 3 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCWTIMER_D4</name>
+              <description>Wide Timer 4 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_DCGCWTIMER_D5</name>
+              <description>Wide Timer 5 Deep-Sleep Mode Clock Gating Control</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRWD</name>
+          <description>Watchdog Timer Peripheral Ready</description>
+          <addressOffset>0x00000A00</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRWD_R0</name>
+              <description>Watchdog Timer 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRWD_R1</name>
+              <description>Watchdog Timer 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRTIMER</name>
+          <description>Timer Peripheral Ready</description>
+          <addressOffset>0x00000A04</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRTIMER_R0</name>
+              <description>Timer 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRTIMER_R1</name>
+              <description>Timer 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRTIMER_R2</name>
+              <description>Timer 2 Peripheral Ready</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRTIMER_R3</name>
+              <description>Timer 3 Peripheral Ready</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRTIMER_R4</name>
+              <description>Timer 4 Peripheral Ready</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRTIMER_R5</name>
+              <description>Timer 5 Peripheral Ready</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRGPIO</name>
+          <description>General-Purpose Input/Output Peripheral Ready</description>
+          <addressOffset>0x00000A08</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRGPIO_R0</name>
+              <description>GPIO Port A Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRGPIO_R1</name>
+              <description>GPIO Port B Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRGPIO_R2</name>
+              <description>GPIO Port C Peripheral Ready</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRGPIO_R3</name>
+              <description>GPIO Port D Peripheral Ready</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRGPIO_R4</name>
+              <description>GPIO Port E Peripheral Ready</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRGPIO_R5</name>
+              <description>GPIO Port F Peripheral Ready</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRDMA</name>
+          <description>Micro Direct Memory Access Peripheral Ready</description>
+          <addressOffset>0x00000A0C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRDMA_R0</name>
+              <description>uDMA Module Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRHIB</name>
+          <description>Hibernation Peripheral Ready</description>
+          <addressOffset>0x00000A14</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRHIB_R0</name>
+              <description>Hibernation Module Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRUART</name>
+          <description>Universal Asynchronous Receiver/Transmitter Peripheral Ready</description>
+          <addressOffset>0x00000A18</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRUART_R0</name>
+              <description>UART Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRUART_R1</name>
+              <description>UART Module 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRUART_R2</name>
+              <description>UART Module 2 Peripheral Ready</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRUART_R3</name>
+              <description>UART Module 3 Peripheral Ready</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRUART_R4</name>
+              <description>UART Module 4 Peripheral Ready</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRUART_R5</name>
+              <description>UART Module 5 Peripheral Ready</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRUART_R6</name>
+              <description>UART Module 6 Peripheral Ready</description>
+              <bitRange>[6:6]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRUART_R7</name>
+              <description>UART Module 7 Peripheral Ready</description>
+              <bitRange>[7:7]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRSSI</name>
+          <description>Synchronous Serial Interface Peripheral Ready</description>
+          <addressOffset>0x00000A1C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRSSI_R0</name>
+              <description>SSI Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRSSI_R1</name>
+              <description>SSI Module 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRSSI_R2</name>
+              <description>SSI Module 2 Peripheral Ready</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRSSI_R3</name>
+              <description>SSI Module 3 Peripheral Ready</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRI2C</name>
+          <description>Inter-Integrated Circuit Peripheral Ready</description>
+          <addressOffset>0x00000A20</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRI2C_R0</name>
+              <description>I2C Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRI2C_R1</name>
+              <description>I2C Module 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRI2C_R2</name>
+              <description>I2C Module 2 Peripheral Ready</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRI2C_R3</name>
+              <description>I2C Module 3 Peripheral Ready</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRUSB</name>
+          <description>Universal Serial Bus Peripheral Ready</description>
+          <addressOffset>0x00000A28</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRUSB_R0</name>
+              <description>USB Module Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRCAN</name>
+          <description>Controller Area Network Peripheral Ready</description>
+          <addressOffset>0x00000A34</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRCAN_R0</name>
+              <description>CAN Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRCAN_R1</name>
+              <description>CAN Module 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRADC</name>
+          <description>Analog-to-Digital Converter Peripheral Ready</description>
+          <addressOffset>0x00000A38</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRADC_R0</name>
+              <description>ADC Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRADC_R1</name>
+              <description>ADC Module 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRACMP</name>
+          <description>Analog Comparator Peripheral Ready</description>
+          <addressOffset>0x00000A3C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRACMP_R0</name>
+              <description>Analog Comparator Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRPWM</name>
+          <description>Pulse Width Modulator Peripheral Ready</description>
+          <addressOffset>0x00000A40</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRPWM_R0</name>
+              <description>PWM Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRPWM_R1</name>
+              <description>PWM Module 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRQEI</name>
+          <description>Quadrature Encoder Interface Peripheral Ready</description>
+          <addressOffset>0x00000A44</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRQEI_R0</name>
+              <description>QEI Module 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRQEI_R1</name>
+              <description>QEI Module 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PREEPROM</name>
+          <description>EEPROM Peripheral Ready</description>
+          <addressOffset>0x00000A58</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PREEPROM_R0</name>
+              <description>EEPROM Module Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRWTIMER</name>
+          <description>Wide Timer Peripheral Ready</description>
+          <addressOffset>0x00000A5C</addressOffset>
+          <fields>
+            <field>
+              <name>SYSCTL_PRWTIMER_R0</name>
+              <description>Wide Timer 0 Peripheral Ready</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRWTIMER_R1</name>
+              <description>Wide Timer 1 Peripheral Ready</description>
+              <bitRange>[1:1]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRWTIMER_R2</name>
+              <description>Wide Timer 2 Peripheral Ready</description>
+              <bitRange>[2:2]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRWTIMER_R3</name>
+              <description>Wide Timer 3 Peripheral Ready</description>
+              <bitRange>[3:3]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRWTIMER_R4</name>
+              <description>Wide Timer 4 Peripheral Ready</description>
+              <bitRange>[4:4]</bitRange>
+            </field>
+            <field>
+              <name>SYSCTL_PRWTIMER_R5</name>
+              <description>Wide Timer 5 Peripheral Ready</description>
+              <bitRange>[5:5]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>UDMA</name>
+      <description>Register map for UDMA peripheral</description>
+      <groupName>UDM</groupName>
+      <prependToName>UDMA</prependToName>
+      <baseAddress>0x400FF000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00001000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt><name>UDMA</name><value>46</value></interrupt>
+      <interrupt><name>UDMAERR</name><value>47</value></interrupt>
+      <registers>
+        <register>
+          <name>STAT</name>
+          <description>DMA Status</description>
+          <addressOffset>0x00000000</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_STAT_MASTEN</name>
+              <description>Master Enable Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_STAT_STATE</name>
+              <description>Control State Machine Status</description>
+              <bitRange>[7:4]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_IDLE</name>
+                  <description>Idle</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_RD_CTRL</name>
+                  <description>Reading channel controller data</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_RD_SRCENDP</name>
+                  <description>Reading source end pointer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_RD_DSTENDP</name>
+                  <description>Reading destination end pointer</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_RD_SRCDAT</name>
+                  <description>Reading source data</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_WR_DSTDAT</name>
+                  <description>Writing destination data</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_WAIT</name>
+                  <description>Waiting for uDMA request to clear</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_WR_CTRL</name>
+                  <description>Writing channel controller data</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_STALL</name>
+                  <description>Stalled</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_DONE</name>
+                  <description>Done</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_STAT_STATE_UNDEF</name>
+                  <description>Undefined</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>UDMA_STAT_DMACHANS</name>
+              <description>Available uDMA Channels Minus 1</description>
+              <bitRange>[20:16]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFG</name>
+          <description>DMA Configuration</description>
+          <addressOffset>0x00000004</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UDMA_CFG_MASTEN</name>
+              <description>Controller Master Enable</description>
+              <bitRange>[0:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLBASE</name>
+          <description>DMA Channel Control Base Pointer</description>
+          <addressOffset>0x00000008</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_CTLBASE_ADDR</name>
+              <description>Channel Control Base Address</description>
+              <bitRange>[31:10]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ALTBASE</name>
+          <description>DMA Alternate Channel Control Base Pointer</description>
+          <addressOffset>0x0000000C</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_ALTBASE_ADDR</name>
+              <description>Alternate Channel Address Pointer</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAITSTAT</name>
+          <description>DMA Channel Wait-on-Request Status</description>
+          <addressOffset>0x00000010</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_WAITSTAT_WAITREQ</name>
+              <description>Channel [n] Wait Status</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWREQ</name>
+          <description>DMA Channel Software Request</description>
+          <addressOffset>0x00000014</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UDMA_SWREQ</name>
+              <description>Channel [n] Software Request</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USEBURSTSET</name>
+          <description>DMA Channel Useburst Set</description>
+          <addressOffset>0x00000018</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_USEBURSTSET_SET</name>
+              <description>Channel [n] Useburst Set</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USEBURSTCLR</name>
+          <description>DMA Channel Useburst Clear</description>
+          <addressOffset>0x0000001C</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UDMA_USEBURSTCLR_CLR</name>
+              <description>Channel [n] Useburst Clear</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>REQMASKSET</name>
+          <description>DMA Channel Request Mask Set</description>
+          <addressOffset>0x00000020</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_REQMASKSET_SET</name>
+              <description>Channel [n] Request Mask Set</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>REQMASKCLR</name>
+          <description>DMA Channel Request Mask Clear</description>
+          <addressOffset>0x00000024</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UDMA_REQMASKCLR_CLR</name>
+              <description>Channel [n] Request Mask Clear</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENASET</name>
+          <description>DMA Channel Enable Set</description>
+          <addressOffset>0x00000028</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_ENASET_SET</name>
+              <description>Channel [n] Enable Set</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENACLR</name>
+          <description>DMA Channel Enable Clear</description>
+          <addressOffset>0x0000002C</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UDMA_ENACLR_CLR</name>
+              <description>Clear Channel [n] Enable Clear</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ALTSET</name>
+          <description>DMA Channel Primary Alternate Set</description>
+          <addressOffset>0x00000030</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_ALTSET_SET</name>
+              <description>Channel [n] Alternate Set</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ALTCLR</name>
+          <description>DMA Channel Primary Alternate Clear</description>
+          <addressOffset>0x00000034</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UDMA_ALTCLR_CLR</name>
+              <description>Channel [n] Alternate Clear</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRIOSET</name>
+          <description>DMA Channel Priority Set</description>
+          <addressOffset>0x00000038</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_PRIOSET_SET</name>
+              <description>Channel [n] Priority Set</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRIOCLR</name>
+          <description>DMA Channel Priority Clear</description>
+          <addressOffset>0x0000003C</addressOffset>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>UDMA_PRIOCLR_CLR</name>
+              <description>Channel [n] Priority Clear</description>
+              <bitRange>[31:0]</bitRange>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ERRCLR</name>
+          <description>DMA Bus Error Clear</description>
+          <addressOffset>0x0000004C</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_ERRCLR_ERRCLR</name>
+              <description>uDMA Bus Error Status</description>
+              <bitRange>[0:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHASGN</name>
+          <description>DMA Channel Assignment</description>
+          <addressOffset>0x00000500</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_CHASGN</name>
+              <description>Channel [n] Assignment Select</description>
+              <bitRange>[31:0]</bitRange>
+              <enumeratedValues>
+                <enumeratedValue>
+                  <name>UDMA_CHASGN_PRIMARY</name>
+                  <description>Use the primary channel assignment</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UDMA_CHASGN_SECONDARY</name>
+                  <description>Use the secondary channel assignment</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHIS</name>
+          <description>DMA Channel Interrupt Status</description>
+          <addressOffset>0x00000504</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_CHIS</name>
+              <description>Channel [n] Interrupt Status</description>
+              <bitRange>[31:0]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHMAP0</name>
+          <description>DMA Channel Map Select 0</description>
+          <addressOffset>0x00000510</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_CHMAP0_CH0SEL</name>
+              <description>uDMA Channel 0 Source Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP0_CH1SEL</name>
+              <description>uDMA Channel 1 Source Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP0_CH2SEL</name>
+              <description>uDMA Channel 2 Source Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP0_CH3SEL</name>
+              <description>uDMA Channel 3 Source Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP0_CH4SEL</name>
+              <description>uDMA Channel 4 Source Select</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP0_CH5SEL</name>
+              <description>uDMA Channel 5 Source Select</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP0_CH6SEL</name>
+              <description>uDMA Channel 6 Source Select</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP0_CH7SEL</name>
+              <description>uDMA Channel 7 Source Select</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHMAP1</name>
+          <description>DMA Channel Map Select 1</description>
+          <addressOffset>0x00000514</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_CHMAP1_CH8SEL</name>
+              <description>uDMA Channel 8 Source Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP1_CH9SEL</name>
+              <description>uDMA Channel 9 Source Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP1_CH10SEL</name>
+              <description>uDMA Channel 10 Source Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP1_CH11SEL</name>
+              <description>uDMA Channel 11 Source Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP1_CH12SEL</name>
+              <description>uDMA Channel 12 Source Select</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP1_CH13SEL</name>
+              <description>uDMA Channel 13 Source Select</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP1_CH14SEL</name>
+              <description>uDMA Channel 14 Source Select</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP1_CH15SEL</name>
+              <description>uDMA Channel 15 Source Select</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHMAP2</name>
+          <description>DMA Channel Map Select 2</description>
+          <addressOffset>0x00000518</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_CHMAP2_CH16SEL</name>
+              <description>uDMA Channel 16 Source Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP2_CH17SEL</name>
+              <description>uDMA Channel 17 Source Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP2_CH18SEL</name>
+              <description>uDMA Channel 18 Source Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP2_CH19SEL</name>
+              <description>uDMA Channel 19 Source Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP2_CH20SEL</name>
+              <description>uDMA Channel 20 Source Select</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP2_CH21SEL</name>
+              <description>uDMA Channel 21 Source Select</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP2_CH22SEL</name>
+              <description>uDMA Channel 22 Source Select</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP2_CH23SEL</name>
+              <description>uDMA Channel 23 Source Select</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHMAP3</name>
+          <description>DMA Channel Map Select 3</description>
+          <addressOffset>0x0000051C</addressOffset>
+          <fields>
+            <field>
+              <name>UDMA_CHMAP3_CH24SEL</name>
+              <description>uDMA Channel 24 Source Select</description>
+              <bitRange>[3:0]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP3_CH25SEL</name>
+              <description>uDMA Channel 25 Source Select</description>
+              <bitRange>[7:4]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP3_CH26SEL</name>
+              <description>uDMA Channel 26 Source Select</description>
+              <bitRange>[11:8]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP3_CH27SEL</name>
+              <description>uDMA Channel 27 Source Select</description>
+              <bitRange>[15:12]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP3_CH28SEL</name>
+              <description>uDMA Channel 28 Source Select</description>
+              <bitRange>[19:16]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP3_CH29SEL</name>
+              <description>uDMA Channel 29 Source Select</description>
+              <bitRange>[23:20]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP3_CH30SEL</name>
+              <description>uDMA Channel 30 Source Select</description>
+              <bitRange>[27:24]</bitRange>
+            </field>
+            <field>
+              <name>UDMA_CHMAP3_CH31SEL</name>
+              <description>uDMA Channel 31 Source Select</description>
+              <bitRange>[31:28]</bitRange>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+  <vendorExtensions>
+    <memory>
+      <name>FLASH</name>
+      <description>FLASH Memory Map for TM4C123GH6PM</description>
+      <baseAddress>0x00000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00040000</size>
+        <usage>FLASH Memory</usage>
+      </addressBlock>
+    </memory>
+    <memory>
+      <name>ROM</name>
+      <description>ROM Memory Map for TM4C123GH6PM</description>
+      <baseAddress>0x01000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00008c00</size>
+        <usage>ROM Boot Loader/TivaWare</usage>
+      </addressBlock>
+    </memory>
+    <memory>
+      <name>SRAM</name>
+      <description>SRAM Memory Map for TM4C123GH6PM</description>
+      <baseAddress>0x20000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x00008000</size>
+        <usage>SRAM</usage>
+      </addressBlock>
+    </memory>
+  </vendorExtensions>
+</device>


### PR DESCRIPTION
I recommend lptm4c1230c3pm.json and TM4C1230C3PM.svd are replaced with 

lptm4c123gh6pm.json and TM4C123GH6PM.svd.

Since TI EK-TM4c123GXL use them.